### PR TITLE
[WIP] Module to parse consolidated helm chart config

### DIFF
--- a/plaidcloud/utilities/config.py
+++ b/plaidcloud/utilities/config.py
@@ -59,6 +59,7 @@ class RedisURLConfig(NamedTuple):
     identity_cache: str = "redis://redis-master/8"
     ipython_registry: str = "redis://redis-master/3"
     oauth_cache: str = "redis://redis-master/9"
+    redis_scheduler: str = "redis://redis-master/13"
     scopes_cache: str = "redis://redis-master/12"
     session: str = "redis://redis-master/0"
     transform_container_registry: str = "redis://redis-master/5"
@@ -119,7 +120,7 @@ class PlaidConfig:
 
     def redis_client(self) -> RedisConfig:
         """Settings for Redis client connections."""
-        redis_config = = self.cfg.get('redisClient', {})
+        redis_config = self.cfg.get('redisClient', {})
         return RedisConfig(**redis_config)
 
     @property

--- a/plaidcloud/utilities/config.py
+++ b/plaidcloud/utilities/config.py
@@ -1,0 +1,139 @@
+3#!/usr/bin/env python
+# coding=utf-8
+"""Loads the configuration file used by workflow monitor.
+"""
+import os
+import yaml
+from typing import NamedTuple
+
+CONFIG_PATH = os.env.get('PLAID_CONFIG_PATH', '/etc/plaid/config.yaml')
+
+
+class DatabaseConfig(NamedTuple):
+    hostname: str
+
+
+class EnvironmentConfig(NamedTuple):
+    hostname: str = "plaidcloud.io"
+    client_id: str
+    designation: str = "dev"
+    tempdir: str = "/tmp"
+    verify_ssl: bool = False
+
+
+class FeatureConfig(NamedTuple):
+    async_copy: bool = True
+    backward_compatible_state: bool = True
+    decrypted_accounts: bool = True
+    enable_cors: bool = False
+    fast_clean_csv: bool = True
+    flashback: bool = True
+    google_login: bool = True
+    table_update_recreate: bool = True
+    use_numeric_cast: bool = True
+
+
+class RMQConfig(NamedTuple):
+    """Connection settings for a RabbitMQ instance."""
+    hostname: str = "rabbit-rabbitmq-ha"
+    port: int = 5679
+    username: str
+    password: str
+    vhost: str
+
+
+class RedisConfig(NamedTuple):
+    """Settings for Redis client connections."""
+    timeout: int = 1
+
+
+class RedisURLConfig(NamedTuple):
+    """URLs for Redis connections."""
+    activity: str = "redis://redis-master/4"
+    analyze_cache: str = "redis://redis-master/6"
+    cron_jobs: str = "redis://redis-master/1"
+    cron_running_jobs: str = "redis://redis-master/2"
+    data_connection_cache: str = "redis://redis-master/11"
+    document_cache: str = "redis://redis-master/7"
+    hierarchy_cache: str = "redis://redis-master/10"
+    identity_cache: str = "redis://redis-master/8"
+    ipython_registry: str = "redis://redis-master/3"
+    oauth_cache: str = "redis://redis-master/9"
+    scopes_cache: str = "redis://redis-master/12"
+    session: str = "redis://redis-master/0"
+    transform_container_registry: str = "redis://redis-master/5"
+
+
+class ServiceConfig(NamedTuple):
+    auth: str = "http://plaid-auth.plaid"
+    client: str = "http://plaid-client.plaid"
+    cron: str = "http://plaid-cron.plaid"
+    data_explorer: str = "http://plaid-data-explorer.plaid"
+    docs: str = "http://plaid-docs.plaid"
+    flashback: str = "http://plaid-flashback.plaid/rpc"
+    monitor: str = "http://plaid-monitor.plaid"
+    plaidxl: str = "http://plaid-plaidxl.plaid"
+    rpc: str = "http://plaid-rpc.plaid/json_rpc"
+    superset: str = "http://plaid-superset.plaid"
+    workflow: str = "http://plaid-workflow.plaid"
+
+
+class PlaidConfig:
+    """Parses a standard configuration file for consumption by python code."""
+    def __init__(self):
+        with open(CONFIG_PATH, 'r') as stream:
+            # Leave exception unhandled. We don't want to start without a valid conf.
+            self.cfg = yaml.safe_load(stream)
+
+    @property
+    def log_level(self):
+        """Default log level for workflow-monitor."""
+        return self.cfg.get('logLevel', 'INFO')
+
+    @property
+    def database(self) -> DatabaseConfig:
+        db_config = self.cfg.get('database', {})
+        return DatabaseConfig(**db_config)
+
+    @property
+    def environment(self) -> EnvironmentConfig:
+        env_config = self.cfg.get('environment', {})
+        return EnvironmentConfig(**env_config)
+
+    @property
+    def features(self) -> FeatureConfig:
+        feature_config = self.cfg.get('features', {})
+        return FeatureConfig(**feature_config)
+
+    @property
+    def kubernetes(self):
+        """Configuration settings for kube-apiserver monitor."""
+        k8s_config = self.cfg.get('kubernetes', {})
+        return KubernetesConfig(**k8s_config)
+
+    @property
+    def rabbitmq(self) -> RMQConfig:
+        """Configuration settings for RabbitMQ connection."""
+        rmq_config = self.cfg.get('rabbitmq', {})
+        return RMQConfig(**rmq_config)
+
+    def redis_client(self) -> RedisConfig:
+        """Settings for Redis client connections."""
+        redis_config = = self.cfg.get('redisClient', {})
+        return RedisConfig(**redis_config)
+
+    @property
+    def redis_urls(self) -> RedisURLConfig:
+        """URLs for Redis connections."""
+        redis_config = self.cfg.get('redis', {})
+        return RedisURLConfig(**redis_config)
+
+    @property
+    def service_urls(self) -> ServiceConfig:
+        svc_config = self.cfg.get('services', {})
+        return ServiceConfig(**svc_config)
+
+    def __str__(self):
+        return repr(self)
+
+config = PlaidConfig()  # pylint: disable=invalid-name

--- a/plaidcloud/utilities/config.py
+++ b/plaidcloud/utilities/config.py
@@ -117,6 +117,7 @@ class PlaidConfig:
         rmq_config = self.cfg.get('rabbitmq', {})
         return RMQConfig(**rmq_config)
 
+    @property
     def redis_client(self) -> RedisConfig:
         """Settings for Redis client connections."""
         redis_config = self.cfg.get('redisClient', {})

--- a/plaidcloud/utilities/config.py
+++ b/plaidcloud/utilities/config.py
@@ -1,7 +1,6 @@
 3#!/usr/bin/env python
 # coding=utf-8
-"""Loads the configuration file used by workflow monitor.
-"""
+"""Loads the configuration file used by plaid apps in kubernetes."""
 import os
 import yaml
 from typing import NamedTuple

--- a/plaidcloud/utilities/config.py
+++ b/plaidcloud/utilities/config.py
@@ -6,7 +6,7 @@ import os
 import yaml
 from typing import NamedTuple
 
-CONFIG_PATH = os.env.get('PLAID_CONFIG_PATH', '/etc/plaid/config.yaml')
+CONFIG_PATH = os.env.get('PLAID_CONFIG_PATH', '/etc/plaidcloud/config.yaml')
 
 
 class DatabaseConfig(NamedTuple):


### PR DESCRIPTION
### What This Does

Parses a file of _common configuration options_ across our applications, mounted by a [consolidated helm chart](https://github.com/PlaidCloud/k8s/pull/164) to each pod in each app deployment. This allows a marketplace deployment of our application stack via helm to dictate the redis/rabbitmq/postgres/etc instances and their credentials to be used by our applications in that deployment. These settings include:

- Feature gates, which may be used cross-application.
- Redis/RMQ/Database credentials and connection info.
- Service URLs, as they are dictated by the helm release name and are subject to change from deployment to deployment.
- Global environment settings, such as the designation (dev, prod, qa, beta), and the hostname being used.
- Possibly other things that I have failed to realize are important to include.

### What This Doesn't Do

Not intended to provide configuration options for each specific applications, such as flask/starlette configurations, credentials to be managed and mounted as separate files (RSA keys, SSL certs, etc), and anything else that would not be versioned in a public repo or distributed publicly. 

### Notes on Implementation

Pretty straightforward implementation that leverages classes that extend `NamedTuple` (so your text editors can leverage type hinting for config objects), and loads the config file sections in as kv pairs and returns the appropriate instance to the caller.

### Questions

1. Should the configuration file being loaded be validated by some public schema?
2. Are there any cross-app configuration settings that I'm missing or would be useful?
3. Is this repo an appropriate publication site for this module?
4. General feedback? Will be made available to all of our apps, so likely (hopefully) won't change much post-merge.

Expanding on question 3, my thinking was to provide this module here so clients that self-host our application stack (citing [this Clubhouse task](https://app.clubhouse.io/plaidcloud/story/7307/enable-plaidcloud-deployment-as-google-marketplace-app)) who intend to write third-party apps could more comfortably integrate with our applications.  

[Here is a link](https://github.com/PlaidCloud/k8s/blob/814a7b87364acdddb8954c8f7da9168b3a9ac318/charts/plaidcloud/templates/configmap.yaml#L9-L53) to the configuration file as defined in the WIP helm chart found here: https://github.com/PlaidCloud/k8s/pull/164