### PR TITLE
Ch7366

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ requests
 setuptools
 orjson
 six
-sqlalchemy
+sqlalchemy==1.4
 sqlalchemy-greenplum
 sqlalchemy-hana
 tables


### PR DESCRIPTION
Refactors sql_expression to allow table numbering to start at numbers other than 1, specifically so that the select query on table2 in antijoin will be able to refer to that table as "table2" in its where clause