### PR TITLE
Ch7010

### DIFF
--- a/plaidcloud/utilities/sql_expression.py
+++ b/plaidcloud/utilities/sql_expression.py
@@ -295,6 +295,7 @@ class Result(object):
             if tc['dtype'] not in ('serial', 'bigserial')
         }
 
+        
 def get_safe_dict(tables, extra_keys=None, table_numbering_start=1):
     """Returns a dict of 'builtins' and table accessor variables for user
     written expressions."""
@@ -497,7 +498,8 @@ def modified_select_query(config, project, metadata, fmt=None, mapping_fn=None, 
                                      " fmt or a mapping_fn!")
         else:
             # A function that formats a string with the provided fmt.
-            def mapping_fn(s): fmt.format(s)
+            def format_with_fmt(s): fmt.format(s)
+            mapping_fn = format_with_fmt
 
     if variables is None:
         variables = {}

--- a/plaidcloud/utilities/sql_expression.py
+++ b/plaidcloud/utilities/sql_expression.py
@@ -177,9 +177,9 @@ def get_from_clause(
     else:
         cast_fn = lambda col, type_: col
 
-    if source is not None:
-        source = source.split('.')[-1]  # If there's a ., the part after the .
-        # otherwise, the whole thing.
+    # if source is not None:
+    #     source = source.split('.')[-1]  # If there's a ., the part after the .
+    #     # otherwise, the whole thing.
 
     if aggregate:
         agg_fn = get_agg_fn(target_column_config.get('agg'))

--- a/plaidcloud/utilities/sql_expression.py
+++ b/plaidcloud/utilities/sql_expression.py
@@ -231,7 +231,8 @@ def get_from_clause(
             else next((
                 c for c in table.columns
                 if c.name == source
-            ), getattr(table.columns, source))
+            # ), getattr(table.columns, source))
+            ), table.columns['source'])
         )
         return sort_fn(
             cast_fn(

--- a/plaidcloud/utilities/sql_expression.py
+++ b/plaidcloud/utilities/sql_expression.py
@@ -232,7 +232,7 @@ def get_from_clause(
                 c for c in table.columns
                 if c.name == source
             # ), getattr(table.columns, source))
-            ), table.columns['source'])
+            ), table.columns[source])
         )
         return sort_fn(
             cast_fn(


### PR DESCRIPTION
Allows column names to have '.' in them. Should still be able to handle '.' as table name. This is necessary to import the adventureworks sample database.

Also small refactors to match pep8 a little better