### PR TITLE
Create a frame with same columns as original

### DIFF
--- a/plaidcloud/utilities/frame_manager.py
+++ b/plaidcloud/utilities/frame_manager.py
@@ -1380,7 +1380,7 @@ def apply_rules(df, df_rules, target_columns=None, include_once=True, show_rules
             if len(matches) > 0:
                 df = pd.concat(matches)
             else:
-                df = pd.DataFrame()
+                df = pd.DataFrame().reindex(columns=df.columns)
         # unmatched record:
         unmatched_length = len(df[df['include'] == True])
         summary.append({


### PR DESCRIPTION
This is to hopefully fix following Traceback seen in Beta from last night:

```
Traceback (most recent call last):
  File "/home/plaid/src/workflow_runner/function/transforms/user_defined.py", line 80, in do
    run_udf_code(transform_code, namespace)
  File "/home/plaid/src/workflow_runner/function/transforms/user_defined.py", line 60, in run_udf_code
    exec(code, namespace)
  File "<string>", line 225, in <module>
  File "/usr/local/lib/python3.8/site-packages/plaidcloud/utilities/frame_manager.py", line 1385, in apply_rules
    unmatched_length = len(df[df['include'] == True])
  File "/usr/local/lib/python3.8/site-packages/pandas/core/frame.py", line 3024, in __getitem__
    indexer = self.columns.get_loc(key)
  File "/usr/local/lib/python3.8/site-packages/pandas/core/indexes/base.py", line 3082, in get_loc
    raise KeyError(key) from err
KeyError: 'include'
```