### PR TITLE
Ch8385

### DIFF
--- a/plaidcloud/utilities/sql_expression.py
+++ b/plaidcloud/utilities/sql_expression.py
@@ -681,7 +681,7 @@ def get_update_value(tc, table, dtype_map, variables):
         return (True, conditional_empty_string_fn(eval_expression(tc['expression'].strip(), variables, [table])))
     if dtype == 'text':
         # Special condition for empty string
-        # ADT2021: I'm suspicious this is attempting to duplicate a bug in 1.0
+        # It works this way because it's impossible to type 'constant': '' in the UI
         return (True, u'')
 
     # If none of our conditions are true, then this column shouldn't be included in the values dict

--- a/plaidcloud/utilities/sql_expression.py
+++ b/plaidcloud/utilities/sql_expression.py
@@ -167,8 +167,8 @@ def get_from_clause(
     name = target_column_config.get('target')
     type_ = sqlalchemy_from_dtype(target_column_config.get('dtype'))
 
-    # always cast expressions, pay attention to cast param for source mappings
-    if not constant and (expression or (source and cast)):
+    # always cast expressions and constants, pay attention to cast param for source mappings
+    if constant or expression or (source and cast):
         cast_fn = curry(sqlalchemy.cast, type_=type_)
     else:
         cast_fn = ident
@@ -520,15 +520,20 @@ def get_select_query(
 
     """
 
+    def fill_in(var, var_name, default):
+        if var is not None:
+            return var
+        return config.get(var_name, default)
+
     config = config or {}
-    aggregate = aggregate or config.get('aggregate', False)
-    having = having or config.get('having', None)
-    use_target_slicer = use_target_slicer or config.get('use_target_slicer', False)
-    limit_target_start = limit_target_start or config.get('limit_target_start', 0)
-    limit_target_end = limit_target_end or config.get('limit_target_end', 0)
-    distinct = distinct or config.get('distinct', False)
-    count = count or config.get('count', False)
-    disable_variables = disable_variables or config.get('disable_variables', False)
+    aggregate = fill_in(aggregate, 'aggregate', False)
+    having = fill_in(having, 'having', None)
+    use_target_slicer = fill_in(use_target_slicer, 'use_target_slicer', False)
+    limit_target_start = fill_in(limit_target_start, 'limit_target_start', 0)
+    limit_target_end = fill_in(limit_target_end, 'limit_target_end', 0)
+    distinct = fill_in(distinct, 'distinct', False)
+    count = fill_in(count, 'count', False)
+    disable_variables = fill_in(disable_variables, 'disable_variables', False)
 
     # Build SELECT x FROM y section of our select query
     if count:

--- a/plaidcloud/utilities/sql_expression.py
+++ b/plaidcloud/utilities/sql_expression.py
@@ -158,7 +158,7 @@ def get_from_clause(
     tables, target_column_config, source_column_configs, aggregate=False,
     sort=False, variables=None, cast=True, disable_variables=False, table_numbering_start=1,
 ):
-    """Given info from a config, returns a sqlalchemy from clause."""
+    """Given info from a config, returns a sqlalchemy expression representing a single target column."""
 
     expression = target_column_config.get('expression')
     constant = target_column_config.get('constant')
@@ -1021,6 +1021,3 @@ def allocate(
     return allocation_select
 
 
-def apply_rules():
-    """"""
-    pass

--- a/plaidcloud/utilities/tests/test_sql_expression.py
+++ b/plaidcloud/utilities/tests/test_sql_expression.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+
+import unittest
+
+import sqlalchemy
+from toolz.functoolz import identity as ident
+
+from plaidcloud.rpc.database import PlaidUnicode
+from plaidcloud.utilities import sql_expression as se
+
+__author__ = "Adams Tower"
+__copyright__ = "© Copyright 2009-2021, Tartan Solutions, Inc"
+__credits__ = ["Adams Tower"]
+__license__ = "Apache 2.0"
+__maintainer__ = "Adams Tower"
+__email__ = "adams.tower@tartansolutions.com"
+
+
+class TestSQLExpression(unittest.TestCase):
+
+    def test_get_project_schema():
+        assert se.get_project_schema('12345') == 'anlz12345'
+        assert se.get_project_schema('anlz12345') == 'anlz12345'
+
+    def test_get_agg_fn():
+        assert se.get_agg_fn(None) == ident
+        assert se.get_agg_fn('') == ident
+        assert se.get_agg_fn('group') == ident
+        assert se.get_agg_fn('dont_group') == ident
+        
+        assert se.get_agg_fn('sum') == sqlalchemy.func.sum
+        assert se.get_agg_fn('count_null') == sqlalchemy.func.count
+
+    def test_get_table_rep():
+        table = se.get_table_rep('table_12345', [{'source': 'Column1', 'dtype': 'text'}, {'source': 'Column2', 'dtype': 'numeric'}], 'anlz_schema')
+        assert isinstance(table, sqlalchemy.Table)
+
+        assert table.name == 'table_12345'
+        assert table.schema == 'anlz_schema'
+        
+        assert len(table.columns) == 2
+        column_1, column_2 = table.columns
+        assert isinstance(column_1, sqlalchemy.Column)
+        assert isinstance(column_2, sqlalchemy.Column)
+        assert column_1.name == 'Column1'
+        assert column_1.type == PlaidUnicode(length=5000)
+        assert column_2.name == 'Column2'
+        assert column_2.type == sqlalchemy.NUMERIC()
+
+        same_table = se.get_table_rep('table_12345', [{'source': 'Column1', 'dtype': 'text'}, {'source': 'Column2', 'dtype': 'numeric'}], 'anlz_schema', metadata=table.metadata)
+        assert table == same_table
+
+        table_using_column_key = se.get_table_rep('table_12345', [{'foobar': 'Column1', 'dtype': 'text'}, {'foobar': 'Column2', 'dtype': 'numeric'}], 'anlz_schema', metadata=table.metadata, column_key='foobar')
+        assert table == table_using_column_key
+
+        aliased_table = se.get_table_rep('table_12345', [{'source': 'Column1', 'dtype': 'text'}, {'source': 'Column2', 'dtype': 'numeric'}], 'anlz_schema', metadata=table.metadata, alias='table_alias')
+        assert isinstance(aliased_table, sqlalchemy.Alias)
+        assert table2.name == 'table_alias'
+
+    def test_get_table_rep_using_id():
+         table = se.get_table_rep('table_12345', [{'source': 'Column1', 'dtype': 'text'}, {'source': 'Column2', 'dtype': 'numeric'}], 'anlz_schema')
+         table2 = se.get_table_rep('table_12345', [{'source': 'Column1', 'dtype': 'text'}, {'source': 'Column2', 'dtype': 'numeric'}], '_schema')
+         assert isinstance(table2, sqlalchemy.Table)
+         assert table.schema == table2.schema
+
+    #TODO: maybe get_table_column next?

--- a/plaidcloud/utilities/tests/test_sql_expression.py
+++ b/plaidcloud/utilities/tests/test_sql_expression.py
@@ -7,6 +7,7 @@ from toolz.functoolz import identity as ident
 
 from plaidcloud.rpc.database import PlaidUnicode
 from plaidcloud.utilities import sql_expression as se
+from plaidcloud.utilities.analyze_table import compiled
 
 __author__ = "Adams Tower"
 __copyright__ = "© Copyright 2009-2021, Tartan Solutions, Inc"
@@ -18,49 +19,425 @@ __email__ = "adams.tower@tartansolutions.com"
 
 class TestSQLExpression(unittest.TestCase):
 
-    def test_get_project_schema():
-        assert se.get_project_schema('12345') == 'anlz12345'
-        assert se.get_project_schema('anlz12345') == 'anlz12345'
+    def assertEquivalent(self, left, right):
+        """Asserts that two sqlalchemy expressions resolve to the same SQL code"""
+        return self.assertEqual(compiled(left), compiled(right))
 
-    def test_get_agg_fn():
-        assert se.get_agg_fn(None) == ident
-        assert se.get_agg_fn('') == ident
-        assert se.get_agg_fn('group') == ident
-        assert se.get_agg_fn('dont_group') == ident
-        
-        assert se.get_agg_fn('sum') == sqlalchemy.func.sum
-        assert se.get_agg_fn('count_null') == sqlalchemy.func.count
+    def test_get_project_schema(self):
+        self.assertEqual(se.get_project_schema('12345'), 'anlz12345')
+        self.assertEqual(se.get_project_schema('anlz12345'), 'anlz12345')
 
-    def test_get_table_rep():
-        table = se.get_table_rep('table_12345', [{'source': 'Column1', 'dtype': 'text'}, {'source': 'Column2', 'dtype': 'numeric'}], 'anlz_schema')
-        assert isinstance(table, sqlalchemy.Table)
+    def test_get_agg_fn(self):
+        self.assertEqual(se.get_agg_fn(None), ident)
+        self.assertEqual(se.get_agg_fn(''), ident)
+        self.assertEqual(se.get_agg_fn('group'), ident)
+        self.assertEqual(se.get_agg_fn('dont_group'), ident)
 
-        assert table.name == 'table_12345'
-        assert table.schema == 'anlz_schema'
-        
-        assert len(table.columns) == 2
+        self.assertEqual(se.get_agg_fn('sum'), sqlalchemy.func.sum)
+        self.assertEqual(se.get_agg_fn('count_null'), sqlalchemy.func.count)
+
+    def test_get_table_rep(self):
+        table = se.get_table_rep(
+            'table_12345',
+            [
+                {'source': 'Column1', 'dtype': 'text'},
+                {'source': 'Column2', 'dtype': 'numeric'},
+            ],
+            'anlz_schema',
+        )
+        self.assertTrue(isinstance(table, sqlalchemy.Table))
+
+        self.assertEqual(table.name, 'table_12345')
+        self.assertEqual(table.schema, 'anlz_schema')
+
+        self.assertEqual(len(table.columns), 2)
         column_1, column_2 = table.columns
-        assert isinstance(column_1, sqlalchemy.Column)
-        assert isinstance(column_2, sqlalchemy.Column)
-        assert column_1.name == 'Column1'
-        assert column_1.type == PlaidUnicode(length=5000)
-        assert column_2.name == 'Column2'
-        assert column_2.type == sqlalchemy.NUMERIC()
+        self.assertTrue(isinstance(column_1, sqlalchemy.Column))
+        self.assertTrue(isinstance(column_2, sqlalchemy.Column))
+        self.assertEqual(column_1.name, 'Column1')
+        self.assertEqual(column_1.type, PlaidUnicode(length=5000))
+        self.assertEqual(column_2.name, 'Column2')
+        self.assertEqual(column_2.type, sqlalchemy.NUMERIC())
 
-        same_table = se.get_table_rep('table_12345', [{'source': 'Column1', 'dtype': 'text'}, {'source': 'Column2', 'dtype': 'numeric'}], 'anlz_schema', metadata=table.metadata)
-        assert table == same_table
+        same_table = se.get_table_rep(
+            'table_12345',
+            [
+                {'source': 'Column1', 'dtype': 'text'},
+                {'source': 'Column2', 'dtype': 'numeric'},
+            ],
+            'anlz_schema',
+            metadata=table.metadata,
+        )
+        self.assertEqual(table, same_table)
 
-        table_using_column_key = se.get_table_rep('table_12345', [{'foobar': 'Column1', 'dtype': 'text'}, {'foobar': 'Column2', 'dtype': 'numeric'}], 'anlz_schema', metadata=table.metadata, column_key='foobar')
-        assert table == table_using_column_key
+        table_using_column_key = se.get_table_rep(
+            'table_12345',
+            [
+                {'foobar': 'Column1', 'dtype': 'text'},
+                {'foobar': 'Column2', 'dtype': 'numeric'},
+            ],
+            'anlz_schema',
+            metadata=table.metadata,
+            column_key='foobar',
+        )
+        self.assertEqual(table, table_using_column_key)
 
-        aliased_table = se.get_table_rep('table_12345', [{'source': 'Column1', 'dtype': 'text'}, {'source': 'Column2', 'dtype': 'numeric'}], 'anlz_schema', metadata=table.metadata, alias='table_alias')
-        assert isinstance(aliased_table, sqlalchemy.Alias)
-        assert table2.name == 'table_alias'
+        aliased_table = se.get_table_rep(
+            'table_12345',
+            [
+                {'source': 'Column1', 'dtype': 'text'},
+                {'source': 'Column2', 'dtype': 'numeric'},
+            ],
+            'anlz_schema',
+            metadata=table.metadata,
+            alias='table_alias',
+        )
+        self.assertTrue(isinstance(aliased_table, sqlalchemy.sql.selectable.Alias))
+        self.assertEqual(aliased_table.name, 'table_alias')
 
-    def test_get_table_rep_using_id():
-         table = se.get_table_rep('table_12345', [{'source': 'Column1', 'dtype': 'text'}, {'source': 'Column2', 'dtype': 'numeric'}], 'anlz_schema')
-         table2 = se.get_table_rep('table_12345', [{'source': 'Column1', 'dtype': 'text'}, {'source': 'Column2', 'dtype': 'numeric'}], '_schema')
-         assert isinstance(table2, sqlalchemy.Table)
-         assert table.schema == table2.schema
+    def test_get_table_rep_using_id(self):
+        table = se.get_table_rep(
+            'table_12345',
+            [
+                {'source': 'Column1', 'dtype': 'text'},
+                {'source': 'Column2', 'dtype': 'numeric'},
+            ],
+            'anlz_schema',
+        )
+        table2 = se.get_table_rep(
+            'table_12345',
+            [
+                {'source': 'Column1', 'dtype': 'text'},
+                {'source': 'Column2', 'dtype': 'numeric'},
+            ],
+            '_schema',
+        )
+        self.assertTrue(isinstance(table2, sqlalchemy.Table))
+        self.assertEqual(table.schema, table2.schema)
 
-    #TODO: maybe get_table_column next?
+    def test_get_column_table(self):
+        self.assertEqual(se.get_column_table(['table1'], None, None), 'table1')
+
+        self.assertEqual(
+            se.get_column_table(
+                ['table1', 'table2'],
+                {
+                    'source': 'foobar',
+                    'target': 'foobar',
+                    'dtype': 'text',
+                    'source_table': 'table1',
+                },
+                None,
+            ),
+            'table1',
+        )
+        self.assertEqual(
+            se.get_column_table(
+                ['table1', 'table2'],
+                {
+                    'source': 'foobar',
+                    'target': 'foobar',
+                    'dtype': 'text',
+                    'source_table': 'table a',
+                },
+                None,
+            ),
+            'table1',
+        )
+        self.assertEqual(
+            se.get_column_table(
+                ['table1', 'table2'],
+                {
+                    'source': 'foobar',
+                    'target': 'foobar',
+                    'dtype': 'text',
+                    'source_table': 'table2',
+                },
+                None,
+            ),
+            'table2',
+        )
+        self.assertEqual(
+            se.get_column_table(
+                ['table1', 'table2'],
+                {
+                    'source': 'foobar',
+                    'target': 'foobar',
+                    'dtype': 'text',
+                    'source_table': 'table b',
+                },
+                None,
+            ),
+            'table2',
+        )
+
+        self.assertEqual(
+            se.get_column_table(
+                ['table1', 'table2', 'table3'],
+                {'source': 'table1.foobar', 'target': 'foobar', 'dtype': 'text'},
+                None,
+            ),
+            'table1',
+        )
+        self.assertEqual(
+            se.get_column_table(
+                ['table1', 'table2', 'table3'],
+                {'source': 'table2.foobar', 'target': 'foobar', 'dtype': 'text'},
+                None,
+            ),
+            'table2',
+        )
+        self.assertEqual(
+            se.get_column_table(
+                ['table1', 'table2', 'table3'],
+                {'source': 'table3.foobar', 'target': 'foobar', 'dtype': 'text'},
+                None,
+            ),
+            'table3',
+        )
+        self.assertEqual(
+            se.get_column_table(
+                ['table1', 'table2', 'table3'],
+                {'source': 'table0.foobar', 'target': 'foobar', 'dtype': 'text'},
+                None,
+                table_numbering_start=0,
+            ),
+            'table1',
+        )
+
+        self.assertEqual(
+            se.get_column_table(
+                ['table1', 'table2', 'table3'],
+                {'source': 'table.foobar', 'target': 'foobar', 'dtype': 'text'},
+                None,
+            ),
+            'table1',
+        )
+
+        source_column_configs = [
+            [
+                {'source': 'foobar', 'dtype': 'text'},
+                {'source': 'barbar', 'dtype': 'text'},
+            ],
+            [
+                {'source': 'barfoo', 'dtype': 'text'},
+                {'source': 'barbar', 'dtype': 'text'},
+            ],
+        ]
+        self.assertEqual(
+            se.get_column_table(
+                ['table1', 'table2'],
+                {'source': 'foobar', 'target': 'foobar', 'dtype': 'text'},
+                source_column_configs,
+            ),
+            'table1',
+        )
+        self.assertEqual(
+            se.get_column_table(
+                ['table1', 'table2'],
+                {'source': 'barfoo', 'target': 'barfoo', 'dtype': 'text'},
+                source_column_configs,
+            ),
+            'table2',
+        )
+        self.assertEqual(
+            se.get_column_table(
+                ['table1', 'table2'],
+                {'source': 'barbar', 'target': 'barbar', 'dtype': 'text'},
+                source_column_configs,
+            ),
+            'table1',
+        )
+
+        with self.assertRaises(se.SQLExpressionError):
+            se.get_column_table(
+                ['table1', 'table2'],
+                {'source': 'foofoo', 'target': 'foofoo', 'dtype': 'text'},
+                source_column_configs,
+            )
+
+    def test_clean_where(self):
+        self.assertEqual(se.clean_where('where_clause'), 'where_clause')
+        self.assertEqual(se.clean_where(' where\n\r_clause '), 'where_clause')
+
+    def test_eval_expression(self):
+        self.assertEqual(se.eval_expression("'foobar'", {}, []), 'foobar')
+
+        self.assertEqual(se.eval_expression("'{var}'", {'var': 'foobar'}, []), 'foobar')
+        self.assertEqual(
+            se.eval_expression(
+                "'{var}'", {'var': 'foobar'}, [], disable_variables=True
+            ),
+            '{var}',
+        )
+
+        table = se.get_table_rep(
+            'table_12345',
+            [
+                {'source': 'Column1', 'dtype': 'text'},
+                {'source': 'Column2', 'dtype': 'numeric'},
+            ],
+            'anlz_schema',
+        )
+        self.assertEqual(se.eval_expression("table", {}, [table]), table)
+        self.assertEqual(se.eval_expression("table1", {}, [table]), table)
+        self.assertEqual(
+            se.eval_expression("table0", {}, [table], table_numbering_start=0), table
+        )
+
+        self.assertEqual(
+            se.eval_expression("foobar", {}, [], extra_keys={'foobar': 123}), 123
+        )
+
+        with self.assertRaises(se.SQLExpressionError):
+            se.eval_expression("1/0", {}, [])
+
+    def test_on_clause(self):
+        table_a = se.get_table_rep(
+            'table_a',
+            [
+                {'source': 'KeyA', 'dtype': 'text'},
+                {'source': 'ValueA', 'dtype': 'numeric'},
+            ],
+            'anlz_schema',
+        )
+        table_b = se.get_table_rep(
+            'table_b',
+            [
+                {'source': 'KeyB', 'dtype': 'text'},
+                {'source': 'ValueB', 'dtype': 'numeric'},
+            ],
+            'anlz_schema',
+        )
+
+        self.assertEquivalent(
+            se.on_clause(table_a, table_b, [{'a_column': 'KeyA', 'b_column': 'KeyB'}]),
+            table_a.columns.KeyA == table_b.columns.KeyB,
+        )
+        self.assertEquivalent(
+            se.on_clause(
+                table_a,
+                table_b,
+                [
+                    {'a_column': 'KeyA', 'b_column': 'KeyB'},
+                    {'a_column': 'ValueA', 'b_column': 'valueB'},
+                ],
+            ),
+            sqlalchemy.and_(
+                table_a.columns.KeyA == table_b.columns.KeyB,
+                table_a.columns.ValueA == table_b.columns.ValueB,
+            ),
+        )
+
+        self.assertEquivalent(
+            se.on_clause(
+                table_a,
+                table_b,
+                [{'a_column': 'KeyA', 'b_column': 'KeyB'}],
+                special_null_handling=True,
+            ),
+            sqlalchemy.or_(
+                table_a.columns.KeyA == table_b.columns.KeyB,
+                sqlalchemy.and_(
+                    table_a.c.KeyA.is_(None),
+                    table_b.c.KeyB.is_(None),
+                ),
+            ),
+        )
+
+    def test_get_from_clause(self):
+        # hoo boy
+        source_column_configs = [
+            {'source': 'Column1', 'dtype': 'text'},
+            {'source': 'Column2', 'dtype': 'numeric'},
+        ]
+        table = se.get_table_rep('table_12345', source_column_configs, 'anlz_schema')
+
+        # Should always return a Label object
+        self.assertTrue(
+            isinstance(
+                se.get_from_clause(
+                    [table],
+                    {'source': 'Column1', 'target': 'TargetColumn', 'dtype': 'text'},
+                    source_column_configs,
+                )
+            ),
+            sqlalchemy.sql.elements.Label,
+        )
+
+        # source
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'source': 'Column1', 'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+            ),
+            sqlalchemy.cast(table.c.Column1, PlaidUnicode(length=5000)).label(
+                'TargetColumn'
+            ),
+        )
+        # TODO: test all the weird stuff related to which table columns come from, table.{}, etc.
+
+        # constant
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'constant': 'foobar', 'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+            ),
+            sqlalchemy.literal('foobar').label('TargetColumn'),
+        )
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'constant': '{var}', 'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+                variables={'var': 'foobar'},
+            ),
+            sqlalchemy.literal('foobar').label('TargetColumn'),
+        )
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'constant': '{var}', 'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+                variables={'var': 'foobar'},
+                disable_variables=True,
+            ),
+            sqlalchemy.literal('{var}').label('TargetColumn'),
+        )
+
+        # expression - more complex tests would just go in test_eval_expression
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'expression': "'foobar'", 'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+            ),
+            sqlalchemy.cast('foobar', PlaudUnicode(length=5000)).label('TargetColumn'),
+        )
+
+        self.assertIsNone(
+            se.get_from_clause(
+                [table],
+                {'target': 'TargetColumn', 'dtype': 'serial'},
+                source_column_configs,
+            )
+        )
+        self.assertIsNone(
+            se.get_from_clause(
+                [table],
+                {'target': 'TargetColumn', 'dtype': 'bigserial'},
+                source_column_configs,
+            )
+        )
+
+        with self.assertRaises(se.SQLExpressionError):
+            se.get_from_clause(
+                [table],
+                {'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+            )
+
+        #TODO: test agg, sort, cast=False, other dtypes, and the stuff I listed in the subsections
+        #TODO: Hmm. Should this be refactored into three smaller functions for constant, expression, source? Plus one for generating the process function I guess? Probably yes, but compleete the tests first.

--- a/plaidcloud/utilities/tests/test_sql_expression.py
+++ b/plaidcloud/utilities/tests/test_sql_expression.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-
 import unittest
 
 import sqlalchemy
@@ -279,10 +278,10 @@ class TestSQLExpression(unittest.TestCase):
             ],
             'anlz_schema',
         )
-        self.assertEqual(se.eval_expression("table", {}, [table]), table)
-        self.assertEqual(se.eval_expression("table1", {}, [table]), table)
+        self.assertEqual(se.eval_expression("table", {}, [table]), table.columns)
+        self.assertEqual(se.eval_expression("table1", {}, [table]), table.columns)
         self.assertEqual(
-            se.eval_expression("table0", {}, [table], table_numbering_start=0), table
+            se.eval_expression("table0", {}, [table], table_numbering_start=0), table.columns
         )
 
         self.assertEqual(
@@ -376,10 +375,79 @@ class TestSQLExpression(unittest.TestCase):
                 'TargetColumn'
             ),
         )
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'source': 'Column1', 'target': 'TargetColumn', 'dtype': 'numeric'},
+                source_column_configs,
+            ),
+            sqlalchemy.cast(table.c.Column1, sqlalchemy.NUMERIC).label(
+                'TargetColumn'
+            ),
+        )
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'source': 'table.Column1', 'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+            ),
+            sqlalchemy.cast(table.c.Column1, PlaidUnicode(length=5000)).label(
+                'TargetColumn'
+            ),
+        )
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'source': 'Column1', 'target': 'TargetColumn', 'dtype': 'text', 'agg': 'count_null'},
+                source_column_configs,
+            ),
+            sqlalchemy.cast(None, PlaidUnicode(length=5000)).label(
+                'TargetColumn'
+            ),
+        )
+
+        with self.assertRaises(se.SQLExpressionError):
+            se.get_from_clause(
+                [table],
+                {'source': 'NonexistentColumn', 'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+            )
+
+        # weird edge case
+        edge_source_column_configs = [
+            {'source': 'column.with.dot', 'dtype': 'text'},
+        ]
+        edge_table = se.get_table_rep('table_12345', edge_source_column_configs, 'anlz_schema')
+        self.assertEquivalent(
+            se.get_from_clause(
+                [edge_table],
+                {'source': 'column.with.dot', 'target': 'TargetColumn', 'dtype': 'text'},
+                edge_source_column_configs,
+            ),
+            sqlalchemy.cast(table.c['column.with.dot'], PlaidUnicode(length=5000)).label(
+                'TargetColumn'
+            ),
+        )
+
+                
+
+        
+
         # TODO: test all the weird stuff related to which table columns come from, table.{}, etc.
 
-        # constant
+        # For source, cast=False means don't cast
         self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'source': 'Column1', 'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+                cast=False,
+            ),
+            table.c.Column1.label('TargetColumn'),
+        )
+
+        # constant
+        self.assertEquivalent)(
             se.get_from_clause(
                 [table],
                 {'constant': 'foobar', 'target': 'TargetColumn', 'dtype': 'text'},
@@ -407,6 +475,36 @@ class TestSQLExpression(unittest.TestCase):
             sqlalchemy.literal('{var}').label('TargetColumn'),
         )
 
+        # For constant columns, cast is irrelevant
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'constant': 'foobar', 'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+            ),
+            se.get_from_clause(
+                [table],
+                {'constant': 'foobar', 'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+                cast=False,
+            ),
+        )
+
+        # For constant columns, aggregate is irrelevant
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'constant': 'foobar', 'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+            ),
+            se.get_from_clause(
+                [table],
+                {'constant': 'foobar', 'target': 'TargetColumn', 'dtype': 'text', 'agg': 'count'},
+                source_column_configs,
+                aggregate=True,
+            ),
+        )
+
         # expression - more complex tests would just go in test_eval_expression
         self.assertEquivalent(
             se.get_from_clause(
@@ -414,9 +512,87 @@ class TestSQLExpression(unittest.TestCase):
                 {'expression': "'foobar'", 'target': 'TargetColumn', 'dtype': 'text'},
                 source_column_configs,
             ),
-            sqlalchemy.cast('foobar', PlaudUnicode(length=5000)).label('TargetColumn'),
+            sqlalchemy.cast('foobar', PlaidUnicode(length=5000)).label('TargetColumn'),
         )
 
+        # For expression columns, cast is irrelevant
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'expression': "'foobar'", 'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+            ),
+            se.get_from_clause(
+                [table],
+                {'expression': "'foobar'", 'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+                cast=False,
+            ),
+        )
+
+        # aggregate means pay attention to the agg param
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'source': "Column1", 'target': 'TargetColumn', 'dtype': 'text', 'agg': 'count'},
+                source_column_configs,
+                aggregate=True,
+            ),
+            sqlalchemy.cast(sqlalchemy.func.count(table.c.Column1), PlaidUnicode(length=5000)).label('TargetColumn')
+        )
+
+        # if aggregate is False or absent, agg param is ignored
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'source': "Column1", 'target': 'TargetColumn', 'dtype': 'text', 'agg': 'count'},
+                source_column_configs,
+            ),
+            se.get_from_clause(
+                [table],
+                {'source': "Column1", 'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+            ),
+        )
+
+        # sort
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'source': "Column1", 'target': 'TargetColumn', 'dtype': 'text', 'sort': {'ascending': True}},
+                source_column_configs,
+                sort=True
+            ),
+            sqlalchemy.asc(sqlalchemy.cast(table.c.Column1, PlaidUnicode(length=5000))).label('TargetColumn')
+        )
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'source': "Column1", 'target': 'TargetColumn', 'dtype': 'text', 'sort': {'ascending': False}},
+                source_column_configs,
+                sort=True
+            ),
+            sqlalchemy.desc(sqlalchemy.cast(table.c.Column1, PlaidUnicode(length=5000))).label('TargetColumn')
+        )
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'source': "Column1", 'target': 'TargetColumn', 'dtype': 'text'},
+                source_column_configs,
+                sort=True
+            ),
+            sqlalchemy.cast(table.c.Column1, PlaidUnicode(length=5000)).label('TargetColumn')
+        )
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'source': "Column1", 'target': 'TargetColumn', 'dtype': 'text', 'sort': {'ascending': True}},
+                source_column_configs
+            ),
+            sqlalchemy.asc(sqlalchemy.cast(table.c.Column1, PlaidUnicode(length=5000))).label('TargetColumn')
+        )
+
+        # If a column doesn't have source, expression or constant, but is serial, return None
         self.assertIsNone(
             se.get_from_clause(
                 [table],
@@ -432,6 +608,7 @@ class TestSQLExpression(unittest.TestCase):
             )
         )
 
+        # If a column doesn't have source, expression or constant, but is any type other than serial/bigserial, raise error
         with self.assertRaises(se.SQLExpressionError):
             se.get_from_clause(
                 [table],
@@ -439,5 +616,406 @@ class TestSQLExpression(unittest.TestCase):
                 source_column_configs,
             )
 
-        #TODO: test agg, sort, cast=False, other dtypes, and the stuff I listed in the subsections
+        # The function application order is sort(cast(agg(x))).label()
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {'source': "Column1", 'target': 'TargetColumn', 'dtype': 'text', 'sort': {'ascending': True}, 'agg': 'count'},
+                source_column_configs,
+                sort=True,
+                aggregate=True,
+            ),
+            sqlalchemy.asc(sqlalchemy.func.count(sqlalchemy.cast(table.c.Column1, PlaidUnicode(length=5000)))).label('TargetColumn')
+        )
+
+        # constant takes priority over expression takes priority over source
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {
+                    'constant': 'barfoo',
+                    'expression': "'foobar'",
+                    'source': 'Column1',
+                    'target': 'TargetColumn',
+                    'dtype': 'text',
+                },
+                source_column_configs,
+            ),
+            sqlalchemy.literal('barfoo').label(
+                'TargetColumn'
+            ),
+        )
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {
+                    'expression': "'foobar'",
+                    'source': 'Column1',
+                    'target': 'TargetColumn',
+                    'dtype': 'text',
+                },
+                source_column_configs,
+            ),
+            sqlalchemy.cast('foobar', PlaidUnicode(length=5000)).label(
+                'TargetColumn'
+            ),
+        )
+        self.assertEquivalent(
+            se.get_from_clause(
+                [table],
+                {
+                    'source': 'Column1',
+                    'target': 'TargetColumn',
+                    'dtype': 'text',
+                },
+                source_column_configs,
+            ),
+            sqlalchemy.cast(table.c.Column1, PlaidUnicode(length=5000)).label(
+                'TargetColumn'
+            ),
+        )
+
         #TODO: Hmm. Should this be refactored into three smaller functions for constant, expression, source? Plus one for generating the process function I guess? Probably yes, but compleete the tests first.
+
+    def test_get_combined_wheres(self):
+        table = se.get_table_rep(
+            'table_12345',
+            [
+                {'source': 'Column1', 'dtype': 'text'},
+                {'source': 'Column2', 'dtype': 'numeric'},
+            ],
+            'anlz_schema',
+        )
+
+        self.assertEquivalent(
+            se.get_combined_wheres(["table.Column1 == 'foo'", "table.Column2 == 0", ""], [table], {})
+            [table.c.Column1 == 'foo', table.c.Column2 == 'bar']
+        )
+
+    def test_get_select_query(self):
+        source_columns =  [
+            {'source': 'Column1', 'dtype': 'text'},
+            {'source': 'Column2', 'dtype': 'numeric'},
+            {'source': 'Column3', 'dtype': 'numeric'},
+        ]
+        table = se.get_table_rep(
+            'table_12345',
+            source_columns,
+            'anlz_schema',
+        )
+        from_clause = curry(se.get_from_clause, [table], [source_columns])
+
+        # Things to test:
+        # basic function
+        target_column = {'target': 'TargetColumn', 'source': 'Column1', 'dtype': 'text'}
+        se.assertEquivalent(
+            se.get_select_query([table], [source_columns], [target_column], []),
+            sqlalchemy.select(from_clause(target_column))
+        )
+        
+        # serial are ignored
+        row_number_tc = {'target': 'RowNumber', 'dtype': 'serial'}
+        se.assertEquivalent(
+            se.get_select_query([table], [source_columns], [target_column, row_number_tc], []),
+            se.get_select_query([table], [source_columns], [target_column], []),
+        )
+
+        # wheres section
+        se.assertEquivalent(
+            se.get_select_query([table], [source_columns], [target_column], ['table.Column2 > 0']),
+            sqlalchemy.select(from_clause(target_column)).where(table.c.Column2 > 0),
+        )
+        
+        # sorting
+        column_2_ascending = {'target': 'Column2', 'source': 'Column2', 'sort': {'ascending': True, 'order': 0}}
+        column_3_descending = {'target': 'Column3', 'source': 'Column3', 'sort': {'ascending': False, 'order': 1}}
+        se.assertEquivalent(
+            se.get_select_query(
+                [table],
+                [source_columns],
+                [target_column, column_2_ascending, column_3_descending],
+                [],
+            ),
+            sqlalchemy.select(
+                from_clause(target_column),
+                from_clause(column_2_ascending),
+                from_clause(column_3_descending),
+            ).order_by(
+                from_clause(column_2_ascending, sort=True),
+                from_clause(column_3_descending, sort=True),
+            ),
+        )
+        # neither select nor sort should include serial columns
+        serial_ascending = {'target': 'RowCount', 'dtype': 'serial', 'sort': {'ascending': True, 'order': 3}}
+        se.assertEquivalent(
+            se.get_select_query([table], [source_columns], [target_column, column_2_ascending, serial_ascending], []),
+            se.get_select_query([table], [source_columns], [target_column, column_2_ascending], []),
+        )
+        # sort should not include columns with malformed sort sections
+        # TODO: malformed is currently defined as missing ascending. I believe missing order will error and that that's a current bug
+        malformed_sort = {'target': 'Column2', 'source': 'Column2', 'sort': {'order': 4}}
+        se.assertEquivalent(
+            se.get_select_query(
+                [table],
+                [source_columns],
+                [target_column, malformed_sort, column_3_descending],
+                [],
+            ),
+            sqlalchemy.select(
+                from_clause(target_column),
+                from_clause(malformed_sort),
+                from_clause(column_3_descending),
+            ).order_by(from_clause(column_3_descending, sort=True)),
+        )
+            
+        # groupby (if aggregate)
+        groupby_column_1 = {'target': 'Category', 'source': 'Column1', 'dtype': 'text', 'agg': 'group'}
+        sum_column_2 = {'target': 'Sum', 'source': 'Column2', 'dtype': 'numeric', 'agg': 'sum'}
+        self.assertEquivalent(
+            se.get_select_query(
+                [table],
+                [source_columns],
+                [groupby_column_1, sum_column_2],
+                [],
+                aggregate=True,
+            ),
+            sqlalchemy.select(
+                from_clause(groupby_column_1, aggregate=True),
+                from_clause(sum_column_2, aggregate=True),
+            ).group_by(from_clause(grouby_column_1, aggregate=False, cast=False)),
+        )
+        # constants aren't included in groupby
+        groupby_constant = {'target': 'Five', 'constant': 5, 'dtype': 'numeric', 'agg': 'group'}
+        self.assertEquivalent(
+            se.get_select_query(
+                [table],
+                [source_columns],
+                [groupby_column_1, groupby_constant, sum_column_2],
+                [],
+                aggregate=True,
+            ),
+            sqlalchemy.select(
+                from_clause(groupby_column_1, aggregate=True),
+                from_clause(groupby_constant, aggregate=True),
+                from_clause(sum_column_2, aggregate=True),
+            ).group_by(from_clause(groupby_column_1, aggregate=False, cast=False)),
+        )
+        # serials aren't included in groupby
+        groupby_serial = {'target': 'RowCount', 'dtype': 'serial', 'agg': 'group'}
+        self.assertEquivalent(
+            se.get_select_query(
+                [table],
+                [source_columns],
+                [groupby_column_1, groupby_serial, sum_column_2],
+                [],
+                aggregate=True,
+            ),
+            sqlalchemy.select(
+                from_clause(groupby_column_1, aggregate=True),
+                from_clause(groupby_serial, aggregate=True),
+                from_clause(sum_column_2, aggregate=True),
+            ).group_by(from_clause(groupby_column_1, aggregate=False, cast=False)),
+        )
+        # don't group by if aggregate is turned off
+        self.assertEquivalent(
+            se.get_select_query(
+                [table],
+                [source_columns],
+                [groupby_column_1, sum_column_2],
+                [],
+                aggregate=False,
+            ),
+            sqlalchemy.select(
+                from_clause(groupby_column_1),
+                from_clause(sum_column_2),
+            ),
+        )
+
+        # distinct
+        distinct_column_1 = {'target': 'Category', 'source': 'Column1', 'dtype': 'text', 'distinct': True}
+        column_2 = {'target': 'Column2', 'source': 'Column2', 'dtype': 'numeric'}
+        self.assertEquivalent(
+            se.get_select_query(
+                [table],
+                [source_columns],
+                [distinct_column_1, column_2],
+                [],
+                distinct=True
+            ),
+            sqlalchemy.select(
+                from_clause(distinct_column_1),
+                from_clause(column_2),
+            ).distinct(from_clause(grouby_column_1)),
+        )
+        # constants aren't included in distinct
+        distinct_constant = {'target': 'Five', 'constant': 5, 'dtype': 'numeric', 'distinct': True}
+        self.assertEquivalent(
+            se.get_select_query(
+                [table],
+                [source_columns],
+                [distinct_column_1, distinct_constant, column_2],
+                [],
+                distinct=True,
+            ),
+            sqlalchemy.select(
+                from_clause(distinct_column_1),
+                from_clause(distinct_constant),
+                from_clause(column_2),
+            ).distinct(from_clause(distinct_column_1)),
+        )
+        # serials aren't included in distinct
+        distinct_serial = {'target': 'RowCount', 'dtype': 'serial', 'distinct': True}
+        self.assertEquivalent(
+            se.get_select_query(
+                [table],
+                [source_columns],
+                [distinct_column_1, distinct_serial, column_2],
+                [],
+                distinct=True,
+            ),
+            sqlalchemy.select(
+                from_clause(distinct_column_1),
+                from_clause(distinct_serial),
+                from_clause(column_2),
+            ).group_by(from_clause(distinct_column_1)),
+        )
+        # don't apply distinct if distinct is turned off
+        self.assertEquivalent(
+            se.get_select_query(
+                [table],
+                [source_columns],
+                [distinct_column_1, column_2],
+                [],
+                distinct=False,
+            ),
+            sqlalchemy.select(
+                from_clause(distinct_column_1),
+                from_clause(column_2),
+            ),
+        )
+
+        # having
+        se.assertEquivalent(
+            se.get_select_query([table], [source_columns], [target_column], [], having='result.TargetColumn != 0'),
+            se.apply_output_filter(se.get_select_query([table], [source_columns], [target_column], []), 'result.TargetColumn != 0')
+        )
+       
+        # use_target_slicer
+        se.assertEquivalent(
+            se.get_select_query([table], [source_columns], [target_column], [], use_target_slicer=True, limit_target_start=10, limit_target_end=100),
+            sqlalchemy.select(from_clause(target_column)).limit(90).offset(10),
+        )
+        # defaults are 0
+        se.assertEquivalent(
+            se.get_select_query([table], [source_columns], [target_column], [], use_target_slicer=True),
+            sqlalchemy.select(from_clause(target_column)).limit(0).offset(0),
+        )
+        # typical use case, 0-10
+        se.assertEquivalent(
+            se.get_select_query([table], [source_columns], [target_column], [], use_target_slicer=True, limit_target_end=10),
+            sqlalchemy.select(from_clause(target_column)).limit(10).offset(0),
+        )
+
+        # count
+        se.assertEquivalent(
+            se.get_select_query([table], [source_columns], [], [], count=True),
+            sqlalchemy.select(sqlalchemy.func.count()).select_from(table),
+        )
+
+        # args from config are the same as args passed in
+        se.assertEquivalent(
+            se.get_select_query(
+                [table],
+                [source_columns],
+                [groupby_column_1, sum_column_2],
+                [],
+                aggregate=True,
+            ),
+            se.get_select_query([table], [source_columns], [groupby_column_1, sum_column_2], [], config={'aggregate': True})
+        )
+        se.assertEquivalent(
+            se.get_select_query([table], [source_columns], [target_column], [], use_target_slicer=True, limit_target_start=10, limit_target_end = 100),
+            se.get_select_query([table], [source_columns], [target_column], [], config={'use_target_slicer': True, 'limit_target_start': 10, 'limit_target_end': 100}),
+        )
+        se.assertEquivalent(
+            se.get_select_query([table], [source_columns], [], [], count=True),
+            se.get_select_query([table], [source_columns], [], [], config={'count': True}),
+        )
+
+        # args passed in take precedence over args from config
+        se.assertEquivalent(
+            se.get_select_query([table], [source_columns], [], [], count=True, config={'count': False}),
+            se.get_select_query([table], [source_columns], [], [], count=True),
+        )
+        # ...unless Falsy (is this intended behavior? - probably fine since all the defaults are Falsy, just a little weird)
+        se.assertEquivalent(
+            se.get_select_query([table], [source_columns], [target_column], [], use_target_slicer=True, limit_target_start=0, limit_target_end=0, config={'limit_target_start': 10, 'limit_target_end': 100}),
+            se.get_select_query([table], [source_columns], [target_column], [], use_target_slicer=True, limit_target_start=10, limit_target_end=100),
+        )
+ 
+        # everything is applied in the right order
+        groupby_column_1_new = {'target': 'Category', 'source': 'Column1', 'dtype': 'text', 'agg': 'group'}
+        sum_column_2_asc = {'target': 'Sum2', 'source': 'Column2', 'dtype': 'numeric', 'agg': 'sum', 'sort': {'ascending': True, 'order': 0}, 'distinct': True}
+        sum_column_3_desc = {'target': 'Sum3', 'source': 'Column3', 'dtype': 'numeric', 'agg': 'sum', 'sort': {'ascending': False, 'order': 1}}
+
+        se.assertEquivalent(
+            se.get_select_query(
+                [table],
+                [source_columns],
+                [groupby_column_1_new, sum_column_2_asc, sum_column_3_desc],
+                ['table.Column2' > 0],
+                aggregate=True,
+                distinct=True,
+                having='result.Category != "foobar"',
+                use_target_slicer=True,
+                limit_target_start=10,
+                limit_target_end=100,
+            ),
+            se.apply_output_filter(
+                sqlalchemy.select(
+                    from_clause(groupby_column_1_new, aggregate=True),
+                    from_clause(sum_column_2_asc, aggregate=True),
+                    from_clause(sum_column_3_desc, aggregate=True),
+                )
+                .where(table.c.Column2 > 0)
+                .order_by(
+                    from_clause(sum_column_2_asc, sort=True, aggregate=True),
+                    from_clause(sum_column_3_desc, sort=True, aggregate=True),
+                )
+                .group_by(
+                    from_clause(groupby_column_1_new, aggregate=False, cast=False)
+                )
+                .distinct(
+                    from_clause(sum_column_2_asc, aggregate=True)
+                ),
+                'result.Category != "foobar"'
+            )
+            .limit(90)
+            .offset(10)
+        )
+
+    def test_apply_output_filter(self):
+        source_columns =  [
+            {'source': 'Column1', 'dtype': 'text'},
+            {'source': 'Column2', 'dtype': 'numeric'},
+            {'source': 'Column3', 'dtype': 'numeric'},
+        ]
+        table = se.get_table_rep(
+            'table_12345',
+            source_columns,
+            'anlz_schema',
+        )
+        from_clause = curry(se.get_from_clause, [table], [source_columns])
+        target_column = {'target': 'TargetColumn', 'source': 'Column1', 'dtype': 'text'}
+        select = sqlalchemy.select(from_clause(target_column))
+        result = select.subquery('result')
+        self.assertEquivalent(
+            se.apply_output_filter(select, 'result.TargetColumn != 0'),
+            sqlalchemy.select(*result.columns).where(result.c.TargetColumn != 0)
+        )
+
+    #TODO: get_insert_query
+    #TODO: get_update_query
+    #TODO: get_delete_query
+    #TODO: import_data_query
+    #TODO: allocate (this is another big one?)

--- a/plaidcloud/utilities/tests/test_sql_expression.py
+++ b/plaidcloud/utilities/tests/test_sql_expression.py
@@ -1581,7 +1581,6 @@ class TestGetUpdateValue(TestSQLExpression):
         )
 
     def test_expression_none_returns_empty_string_for_text(self):
-        # TODO: test this against version 1.0 (will require testing at the "get_update_query" level)
         empty_string_col = {'source': 'Column1', 'expression': 'None'}
         self.assertEqual(
             se.get_update_value(empty_string_col, self.table, self.dtype_map, {}),
@@ -1589,7 +1588,6 @@ class TestGetUpdateValue(TestSQLExpression):
         )
 
     def test_include_because_text(self):
-        #TODO: also test this against version 1.0, but I think it's a bug
         include_because_text_col = {'source': 'Column1'}
         self.assertEqual(
             se.get_update_value(include_because_text_col, self.table, self.dtype_map, {}),
@@ -1645,7 +1643,7 @@ class TestGetUpdateQuery(TestSQLExpression):
         )
 
     def test_empty_string_no_matter_what(self):
-        # This one seems wrong
+        # This one seems wrong, but it matches v1.0.0's behavior. I think we should change hwo this works unless there's a good reason for it?
         include_because_text_col = {'source': 'Column1'}
         self.assertEquivalent(
             se.get_update_query(self.table, [include_because_text_col], [], self.dtype_map),

--- a/plaidcloud/utilities/tests/test_sql_expression.py
+++ b/plaidcloud/utilities/tests/test_sql_expression.py
@@ -313,7 +313,7 @@ class TestCleanWhere(TestSQLExpression):
     def test_trims(self):
         self.assertEqual(se.clean_where(' where_clause '), 'where_clause')
 
-class TeestEvalExpression(TestSQLExpression):
+class TestEvalExpression(TestSQLExpression):
     def setUp(self):
         self.table = se.get_table_rep(
             'table_12345',

--- a/plaidcloud/utilities/tests/test_sql_expression.py
+++ b/plaidcloud/utilities/tests/test_sql_expression.py
@@ -1042,12 +1042,11 @@ class TestGetSelectQuery(TestSQLExpression):
             ),
         )
 
-     # this one errors in v1.0.0 because apply_output_filter has a default of None for the variables param, but None isn't a valid value for that param. In the new version I've changed it to a better default. But I also don't believe apply_output_filter is ever called in our actual code without providing a variables dict
     def test_having(self):
         # having
         self.assertEquivalent(
             se.get_select_query([self.table], [self.source_columns], [self.target_column], [], having='result.TargetColumn != 0'),
-            se.apply_output_filter(se.get_select_query([self.table], [self.source_columns], [self.target_column], []), 'result.TargetColumn != 0')
+            se.apply_output_filter(se.get_select_query([self.table], [self.source_columns], [self.target_column], []), 'result.TargetColumn != 0', {})
         )
 
     def test_use_target_slicer(self):
@@ -1105,7 +1104,6 @@ class TestGetSelectQuery(TestSQLExpression):
             se.get_select_query([self.table], [self.source_columns], [self.target_column], [], use_target_slicer=True, limit_target_start=0, limit_target_end=0),
         )
 
-    # this one errors in v1.0.0 because apply_output_filter has a default of None for the variables param, but None isn't a valid value for that param. In the new version I've changed it to a better default. But I also don't believe apply_output_filter is ever called in our actual code without providing a variables dict
     def test_order(self):
         # everything is applied in the right order
         groupby_column_1_new = {'target': 'Category', 'source': 'Column1', 'dtype': 'text', 'agg': 'group'}
@@ -1142,7 +1140,8 @@ class TestGetSelectQuery(TestSQLExpression):
                 .distinct(
                     self.from_clause(sum_column_2_asc, aggregate=True)
                 ),
-                'result.Category != "foobar"'
+                'result.Category != "foobar"',
+                {},
             )
             .limit(90)
             .offset(10)
@@ -1264,7 +1263,6 @@ class TestModifiedSelectQuery(TestSQLExpression):
         )
 
 class TestApplyOutputFilter(TestSQLExpression):
-    # Again, this fails because apply_output_filter has a bad default value for variables.
     def test_apply_output_filter(self):
         source_columns =  [
             {'source': 'Column1', 'dtype': 'text'},
@@ -1281,7 +1279,7 @@ class TestApplyOutputFilter(TestSQLExpression):
         select = sqlalchemy.select(from_clause(target_column))
         result = select.subquery('result')
         self.assertEquivalent(
-            se.apply_output_filter(select, 'result.TargetColumn != 0'),
+            se.apply_output_filter(select, 'result.TargetColumn != 0', {}),
             sqlalchemy.select(*result.columns).where(result.c.TargetColumn != 0)
         )
 

--- a/plaidcloud/utilities/tests/test_sql_expression.py
+++ b/plaidcloud/utilities/tests/test_sql_expression.py
@@ -1641,7 +1641,7 @@ class TestGetUpdateQuery(TestSQLExpression):
         )
 
     def test_empty_string_no_matter_what(self):
-        # This one seems wrong, but it matches v1.0.0's behavior. I think we should change hwo this works unless there's a good reason for it?
+        # It works this way because it's impossible to type 'constant': '' in the UI
         include_because_text_col = {'source': 'Column1'}
         self.assertEquivalent(
             se.get_update_query(self.table, [include_because_text_col], [], self.dtype_map),


### PR DESCRIPTION
Adds unit tests to sql expression. The majority of them pass for both v1.0.0 and the code included in this PR.

Those that don't:
* All tests of import_data_query error in v1.0.0, because import_data_query generates a uuid for the name of its temp table. I modified it to allow the caller to pass in a temp table name, for testing purposes, so that the output is predictable.
* All tests of get_update_value error in v1.0.0, because the function doesn't exist. I separated it out in order to both make the code for get_update_query cleaner, and also to make testing simpler and more thorough.
* In v1.0.0, TestGetSelectQuery.test_put_columns_without_order_at_end_of_sort errors, because columns with a sort param but not an order param cause a KeyError. Columns with a sort param but no ascending param are just ignored for order_by. I've added what I think is a reasonable behavior, if columns without a sort order are passed in - they get put at the end, after any columns that do have a sort order. I'm not actually sure it's possible to send in a column with a sort param but no order param in the UI.
* in v1.0.0, TestGetColumnTable.test_table_dot_column errors, despite code to handle that specific case of 'table.column', because the code to handle 'tableN.column' catches it and then gets confused when there's no N. In the current, I've reversed the order of those handlers, so we can get what seems to be the intended behavior.

Besides that, this PR:
* removes the unused function apply_rules
* adds explanatory comments in several places
* fixes places where v1.0.2's behavior did not match v1.0.0
* adds a default value for the metadata param to get_table_rep_using_id, in order to match the api of get_table_rep, which has that default value.
* fixes the default value for the variables param in apply_output_filter, so using that default value no longer causes an error
* makes import_data_query non-destructive
* adds some refactoring TODO comments