### PR TITLE
Ch8649

### DIFF
--- a/plaidcloud/utilities/data_helpers.py
+++ b/plaidcloud/utilities/data_helpers.py
@@ -8,11 +8,13 @@ import re
 import math
 import platform
 import locale
+import functools
+
+import numpy as np
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
-import numpy as np
 import texttable
-import functools
+
 # Note: one function imports from IPython
 
 __author__ = 'Michael Rea'
@@ -629,16 +631,8 @@ def to_xl(df_source,
         sht = _get_sheet(wb, sheet)
         sht.clear()  # clear contents of worksheet
 
-        # if six.PY3:
-        #     # convert any byte strings to string to avoid 'b' prefix bug in pandas
-        #     # https://github.com/pandas-dev/pandas/issues/9712
-        #     str_df = df.select_dtypes([np.object])
-        #     str_df = str_df.stack().str.decode('utf-8').unstack()
-        #     for col in str_df:
-        #         df[col] = str_df[col]
-
         def force_text(item):
-            return "'{}".format(str(item))
+            return f"'{item}"
 
         for col in df.columns:
             cur_type = df[col].dtype
@@ -951,8 +945,8 @@ def safe_divide(numerator, denominator, error_return_value=0):
 
     if pd.isna(result) or abs(result) == np.inf or pd.isnull(result):
         return error_return_value
-    else:
-        return result
+
+    return result
 
 
 def remove_all(string, substrs):

--- a/plaidcloud/utilities/data_helpers.py
+++ b/plaidcloud/utilities/data_helpers.py
@@ -12,8 +12,8 @@ import pandas as pd
 from pandas.api.types import is_numeric_dtype
 import numpy as np
 import texttable
-from IPython.core.display import HTML
 import functools
+# Note: one function imports from IPython
 
 __author__ = 'Michael Rea'
 __copyright__ = ' Copyright 2014-2019, Tartan Solutions, Inc'
@@ -114,6 +114,9 @@ def jupyter_table(input):
     Also, it will work on non-pandas stuff where browser-based
     line wrapping is not desired.
     """
+
+    # Importing here because IPython is a big import that we don't need for anything else in data_helpers
+    from IPython.core.display import HTML
 
     # TODO: Just make this an option of inspect
     jupyter_wrapper = ''.join(['<div style="font-weight: normal;font-family: monospace;white-space:pre;">', input, '</div>'])

--- a/plaidcloud/utilities/frame_manager.py
+++ b/plaidcloud/utilities/frame_manager.py
@@ -11,16 +11,14 @@ import string
 from functools import wraps
 from io import BytesIO
 import traceback
-import xlrd3 as xlrd
-
-import unicodecsv as csv
 from math import log10, floor
 
-from pandas.api.types import is_string_dtype
+import xlrd3 as xlrd
+import unicodecsv as csv
 import pandas as pd
+from pandas.api.types import is_string_dtype
 import numpy as np
 import orjson as json
-
 
 from plaidcloud.rpc import utc
 from plaidcloud.rpc.connection.jsonrpc import SimpleRPC
@@ -1643,12 +1641,10 @@ def column_info(df):
             Dtypes
     """
 
-    column_info = []
-    for column_name, data_type in df.dtypes.items():
-        temp = {'id': column_name, 'dtype': str(data_type)}
-        column_info.append(temp)
-
-    return column_info
+    return [
+        {'id': column_name, 'dtype': str(data_type)}
+        for column_name, data_type in df.dtypes.items()
+    ]
 
 
 def set_column_types(df, type_dict):
@@ -1807,16 +1803,12 @@ def has_data(df):
     Returns:
         bool: If `df` has any data
     """
-    row_max = 0
     try:
-        for k, v in df.count().items():
-            row_max = max(row_max, int(v))
+        counts = [int(v) for v in df.count().values()]
+        if not counts:
+            return False
+        return max(counts) > 0
     except:
-        pass
-
-    if row_max > 0:
-        return True
-    else:
         return False
 
 def convert_currency(
@@ -2603,7 +2595,7 @@ def excel_to_csv_openpyxl(excel_file_name, csv_file_name, sheet_name='sheet1', c
                 ])
                 header_done = True
             else:
-                if clean and all([cell is None for cell in row]):
+                if clean and all(cell is None for cell in row):
                     # Skip rows that have no data.
                     skipped_rows += 1
                     continue

--- a/plaidcloud/utilities/frame_manager.py
+++ b/plaidcloud/utilities/frame_manager.py
@@ -1804,12 +1804,13 @@ def has_data(df):
         bool: If `df` has any data
     """
     try:
-        counts = [int(v) for v in df.count().values()]
+        counts = [int(v) for v in df.count().values]
         if not counts:
             return False
         return max(counts) > 0
     except:
         return False
+
 
 def convert_currency(
     df_data,

--- a/plaidcloud/utilities/frame_manager.py
+++ b/plaidcloud/utilities/frame_manager.py
@@ -12,7 +12,7 @@ from functools import wraps
 from io import BytesIO
 import traceback
 import xlrd3 as xlrd
-import openpyxl
+
 import unicodecsv as csv
 from math import log10, floor
 
@@ -2369,12 +2369,6 @@ def excel_to_csv(excel_file_name, csv_file_name, sheet_name='sheet1', clean=Fals
         skip_rows (int, optional): The number of rows to skip at the top of the file
     """
     return excel_to_csv_xlrd(excel_file_name, csv_file_name, sheet_name, clean, has_header, skip_rows)
-    # try:
-    #     openpyxl.load_workbook(excel_file_name, read_only=True)
-    # except:
-    #     logger.exception(f'Unable to open workbook with openpyxl: {excel_file_name}')
-    #     return excel_to_csv_xlrd(excel_file_name, csv_file_name, sheet_name, clean, has_header, skip_rows)
-    # return excel_to_csv_openpyxl(excel_file_name, csv_file_name, sheet_name, clean, has_header, skip_rows)
 
 
 def excel_to_csv_xlrd(excel_file_name, csv_file_name, sheet_name='sheet1', clean=False, has_header=True, skip_rows=0):
@@ -2578,6 +2572,9 @@ def excel_to_csv_openpyxl(excel_file_name, csv_file_name, sheet_name='sheet1', c
         has_header (bool, optional): The file has a header row
         skip_rows (int, optional): The number of rows to skip at the top of the file
     """
+    # Importing openpyxl here because it's a slightly heavy import and we don't even use it
+    import openpyxl
+
     logger.debug('opening workbook for conversion')
     wb = openpyxl.load_workbook(excel_file_name, read_only=True, data_only=True, keep_links=False, keep_vba=False)
     logger.debug('Workbook Open')

--- a/plaidcloud/utilities/frame_manager.py
+++ b/plaidcloud/utilities/frame_manager.py
@@ -199,20 +199,17 @@ def list_of_dicts_to_typed_psv(lod, outfile, types, fieldnames=None, sep='|'):
         # Caller doesn't care about the order
         fieldnames = list(types.keys())
 
-    if isinstance(outfile, str):
-        buf = open(outfile, 'wb')
-    else:
-        buf = outfile
-
-    try:
+    def write(buf):
         writer = csv.DictWriter(buf, fieldnames=fieldnames, delimiter=sep)
         writer.writerow(header)  # It's not just the keys, so we're not using writeheader
         for row in lod:
             writer.writerow(row)
-    finally:
-        if isinstance(outfile, str):
-            buf.close()
-            #Otherwise leave it open, since this function didn't open it.
+
+    if isinstance(outfile, str):
+        with open(outfile, 'wb') as buf:
+            write(buf)
+    else:
+        write(outfile)
 
 
 def get_project_variables(token, uri, project_id):


### PR DESCRIPTION
A lot of changes remove python 2 support, but the most important commits are:

```Moves IPython import inside the only function that uses it```
```Moves openpyxl import inside the only (unused) function that uses it```

These move heavy imports inside the functions that use them, so that they're only imported when they're needed. There's a lot of benefit to that in my testing methodology, though less in a production system where pods live longer. There could be greater benefit to importing everything when a pod spins up before we start listening for requests.