### PR TITLE
Ignore magic columns in from_clause evaluation

### DIFF
--- a/plaidcloud/utilities/sql_expression.py
+++ b/plaidcloud/utilities/sql_expression.py
@@ -258,7 +258,7 @@ def get_from_clause(
         return expression_from_clause(expression, tables, sort_type, cast_type, agg_type, name, variables, disable_variables, table_numbering_start)
     if source:
         return source_from_clause(source, tables, target_column_config, source_column_configs, cast, sort_type, cast_type, agg_type, name, table_numbering_start)
-    if target_column_config.get('dtype') in ('serial', 'bigserial'):
+    if target_column_config.get('dtype') in {'serial', 'bigserial'}.union(set(MAGIC_COLUMN_MAPPING.keys())):
         return None
 
     # If we get here...

--- a/plaidcloud/utilities/tests/test_sql_expression.py
+++ b/plaidcloud/utilities/tests/test_sql_expression.py
@@ -748,6 +748,16 @@ class TestGetFromClause(TestSQLExpression):
             )
         )
 
+    def test_magic_columns_is_none(self):
+        for dtype in se.MAGIC_COLUMN_MAPPING.keys():
+            self.assertIsNone(
+                se.get_from_clause(
+                    [self.table],
+                    {'target': 'TargetColumn', 'dtype': dtype},
+                    self.source_column_configs,
+                )
+            )
+
     def test_errors_when_no_source_expression_or_constant(self):
         # If a column doesn't have source, expression or constant, but is any type other than serial/bigserial, raise error
         with self.assertRaises(se.SQLExpressionError):


### PR DESCRIPTION
 * These data types are actually only used in get_import_query