### PR TITLE
Allow use of variables in Table explorer filters

### DIFF
--- a/plaidcloud/utilities/frame_manager.py
+++ b/plaidcloud/utilities/frame_manager.py
@@ -1276,6 +1276,7 @@ def apply_rules(df, df_rules, target_columns=None, include_once=True, show_rules
             df[column] = ''
 
     summary = []
+    row_num = 0
     iterations = list(set(df_rules[iteration_column]))
     iterations.sort()
     for iteration in iterations:
@@ -1303,7 +1304,6 @@ def apply_rules(df, df_rules, target_columns=None, include_once=True, show_rules
                 return '{}, {}'.format(rule_id, str(rule[rule_id_column]))
 
         matches = []  # for use when include_once is False
-        index = 0
         for index, rule in df_rules[df_rules[iteration_column] == iteration].iterrows():
             # Find subset based on condition
             df_subset = df[df['include'] == True]
@@ -1368,13 +1368,14 @@ def apply_rules(df, df_rules, target_columns=None, include_once=True, show_rules
                     matches.append(df_subset)
 
             summary_record = {
-                'row_num': index,
+                'row_num': row_num,
                 iteration_column: iteration,
                 'input_records': input_length,
                 'matched_records': matched_length,
             }
             summary_record.update(rule)
             summary.append(summary_record)
+            row_num += 1
 
         if include_once is False:
             if len(matches) > 0:
@@ -1384,12 +1385,13 @@ def apply_rules(df, df_rules, target_columns=None, include_once=True, show_rules
         # unmatched record:
         unmatched_length = len(df[df['include'] == True])
         summary.append({
-            'row_num': index+1,
+            'row_num': row_num,
             iteration_column: iteration,
             'input_records': unmatched_length,
             'matched_records': unmatched_length,
             'rule': unmatched_rule
         })
+        row_num += 1
 
     df_summary = pd.DataFrame.from_records(summary)
     if show_rules is True:

--- a/plaidcloud/utilities/sql_expression.py
+++ b/plaidcloud/utilities/sql_expression.py
@@ -53,10 +53,13 @@ filter_nulls = curry(valfilter, lambda v: v is not None)
 def eval_expression(expression, variables, tables, extra_keys=None, disable_variables=False, table_numbering_start=1):
     safe_dict = get_safe_dict(tables, extra_keys, table_numbering_start=table_numbering_start)
 
-    if disable_variables:
-        expression_with_variables = expression
-    else:
+    try:
         expression_with_variables = apply_variables(expression, variables)
+    except:
+        if disable_variables:
+            expression_with_variables = expression
+        else:
+            raise
 
     compiled_expression = compile(expression_with_variables, '<string>', 'eval')
 


### PR DESCRIPTION
Allow variables in table explorer filters until they cause an error, then disable. This allows you to use them most of the while, unless you are filtering by a column data and that column data contains some curly braces. Slightly better than just disabling the whole time.

Also includes fix for putting the correct row number into the summary table when running apply_rules