### PR TITLE
Fix imports

### DIFF
--- a/plaidcloud/utilities/frame_manager.py
+++ b/plaidcloud/utilities/frame_manager.py
@@ -2304,7 +2304,7 @@ def json_to_csv(json_file_name, csv_file_name, columns=None, writeheader=True):
                 extrasaction='ignore',
                 delimiter='\t',
                 quotechar='"',
-                escapechar='\\'
+                escapechar='"'
             )
             if writeheader:
                 wr.writeheader()
@@ -2414,7 +2414,7 @@ def excel_to_csv_xlrd(excel_file_name, csv_file_name, sheet_name='sheet1', clean
             csv_file,
             delimiter='\t',
             quotechar='"',
-            escapechar='\\',
+            escapechar='"',
         )
         skipped_rows = 0
         # Do some cleaning to account for common human errors
@@ -2603,7 +2603,7 @@ def excel_to_csv_openpyxl(excel_file_name, csv_file_name, sheet_name='sheet1', c
             csv_file,
             delimiter='\t',
             quotechar='"',
-            escapechar='\\',
+            escapechar='"',
         )
 
         skipped_rows = 0
@@ -2671,7 +2671,7 @@ def fixedwidth_to_csv(fixed_width_file_name, csv_file_name, colspecs):
         index=False,
         sep='\t',
         quotechar='"',
-        escapechar='\\',
+        escapechar='"',
     )
 
 
@@ -2693,7 +2693,7 @@ def avro_to_csv(avro_file_name, csv_file_name, start_row=0):
                 fieldnames=header,
                 delimiter='\t',
                 quotechar='"',
-                escapechar='\\',
+                escapechar='"',
             )
             writer.writeheader()
             writer.writerows(reader)
@@ -2708,7 +2708,7 @@ def parquet_to_csv(parquet_file_name, csv_file_name, start_row=0):
         index=False,
         sep='\t',
         quotechar='"',
-        escapechar='\\',
+        escapechar='"',
     )
 
 

--- a/plaidcloud/utilities/query.py
+++ b/plaidcloud/utilities/query.py
@@ -499,7 +499,7 @@ class Connection:
                     delimiter='\t',
                     null_as='NaN',
                     quote='"',
-                    escape='\\',
+                    escape='"',
                     append=append or row > 0,
                     compressed=True,
                 )


### PR DESCRIPTION
So, now it seems everything works better with the double double quotes. The `xsv` module will read a file escaped with a backslash, but it doubles up any other back slashes in the file. Anyhow, I was able to get this to work with Databend, an escapechar of `"` is the same as a blank string in Databend.