### PR TITLE
Change distinct behaviour

### DIFF
--- a/plaidcloud/utilities/sql_expression.py
+++ b/plaidcloud/utilities/sql_expression.py
@@ -684,24 +684,29 @@ def get_select_query(
 
     # Build DISTINCT section of our select query
     if distinct:
-        select_query = select_query.distinct(
-            *[
-                get_from_clause(
-                    tables,
-                    tc,
-                    source_columns,
-                    aggregate,
-                    variables=variables,
-                    disable_variables=disable_variables,
-                    table_numbering_start=table_numbering_start,
-                    use_row_number_for_serial=use_row_number_for_serial,
-                )
-                for tc in target_columns
-                if not tc.get('constant')
-                and tc.get('distinct')
-                and (use_row_number_for_serial or not tc.get('dtype') in ('serial', 'bigserial'))
-            ]
-        )
+        # if any([tc for tc in target_columns if not tc.get('distinct')]):
+        #     raise Exception('Distinct cannot be used if all columns are not distinct')
+        # every other database way
+        select_query = select_query.distinct()
+        # postgres way of doing distinct (*args) will become CompileError in future
+        # select_query = select_query.distinct(
+        #     *[
+        #         get_from_clause(
+        #             tables,
+        #             tc,
+        #             source_columns,
+        #             aggregate,
+        #             variables=variables,
+        #             disable_variables=disable_variables,
+        #             table_numbering_start=table_numbering_start,
+        #             use_row_number_for_serial=use_row_number_for_serial,
+        #         )
+        #         for tc in target_columns
+        #         if not tc.get('constant')
+        #         and tc.get('distinct')
+        #         and (use_row_number_for_serial or not tc.get('dtype') in ('serial', 'bigserial'))
+        #     ]
+        # )
 
     # HAVING
     if having:

--- a/plaidcloud/utilities/tests/test_sql_expression.py
+++ b/plaidcloud/utilities/tests/test_sql_expression.py
@@ -1121,7 +1121,9 @@ class TestGetSelectQuery(TestSQLExpression):
             sqlalchemy.select(
                 self.from_clause(self.distinct_column_1),
                 self.from_clause(self.column_2),
-            ).distinct(self.from_clause(self.distinct_column_1)),
+            ).distinct(
+            #    self.from_clause(self.distinct_column_1)
+            ),
         )
 
     def test_dont_distinct_on_constant(self):
@@ -1139,7 +1141,9 @@ class TestGetSelectQuery(TestSQLExpression):
                 self.from_clause(self.distinct_column_1),
                 self.from_clause(distinct_constant),
                 self.from_clause(self.column_2),
-            ).distinct(self.from_clause(self.distinct_column_1)),
+            ).distinct(
+                #self.from_clause(self.distinct_column_1)
+            ),
         )
 
     def test_dont_distinct_on_serial(self):
@@ -1157,7 +1161,9 @@ class TestGetSelectQuery(TestSQLExpression):
             sqlalchemy.select(
                 self.from_clause(self.distinct_column_1, use_row_number_for_serial=False),
                 self.from_clause(self.column_2, use_row_number_for_serial=False),
-            ).distinct(self.from_clause(self.distinct_column_1, use_row_number_for_serial=False)),
+            ).distinct(
+                #self.from_clause(self.distinct_column_1, use_row_number_for_serial=False)
+            ),
         )
 
     def test_distinct_on_serial_row_number(self):
@@ -1169,8 +1175,8 @@ class TestGetSelectQuery(TestSQLExpression):
                 self.from_clause(distinct_serial),
                 self.from_clause(self.column_2),
             ).distinct(
-                self.from_clause(self.distinct_column_1),
-                self.from_clause(distinct_serial),
+                #self.from_clause(self.distinct_column_1),
+                #self.from_clause(distinct_serial),
             ),
             se.get_select_query(
                 [self.table],
@@ -1294,7 +1300,7 @@ class TestGetSelectQuery(TestSQLExpression):
                     self.from_clause(groupby_column_1_new, aggregate=False, cast=False)
                 )
                 .distinct(
-                    self.from_clause(sum_column_2_asc, aggregate=True)
+                    #self.from_clause(sum_column_2_asc, aggregate=True)
                 ),
                 'result.Category != "foobar"',
                 {},


### PR DESCRIPTION
Distinct on databases other than postgres is called on the whole select. Currently it raises a warning, but that will become an error in future. Call the SQLAlchemy without the column setting