### PR TITLE
table cannot be specified as kwarg for SQLA2.0

### DIFF
--- a/plaidcloud/utilities/query.py
+++ b/plaidcloud/utilities/query.py
@@ -664,7 +664,7 @@ class Connection:
         # ensure the table exists as per the metadata
         table = Table(
             self,
-            table=table if isinstance(table, str) else table.id,
+            table if isinstance(table, str) else table.id,
             columns=_table_meta(),
             overwrite=not append
         )


### PR DESCRIPTION
Took way more debugging than it should've done, but got there in the end.