### PR TITLE
Ensure paramstyle 'pyformat' for db connection

### DIFF
--- a/plaidcloud/utilities/analyze_table.py
+++ b/plaidcloud/utilities/analyze_table.py
@@ -141,7 +141,7 @@ def compiled(sa_query, dialect='greenplum'):
             dict: query parameters
     """
     dialect = dialect or 'greenplum'  # Just in case someone sends a blank string, or a None by mistake
-    eng = sqlalchemy.create_engine(f'{dialect}://127.0.0.1/')
+    eng = sqlalchemy.create_engine(f'{dialect}://127.0.0.1/', paramstyle='pyformat')
     compiled_query = sa_query.compile(dialect=eng.dialect, compile_kwargs={"render_postcompile": True})
     return str(compiled_query).replace('\n', ''), compiled_query.params
 

--- a/plaidcloud/utilities/query.py
+++ b/plaidcloud/utilities/query.py
@@ -91,7 +91,7 @@ class Connection:
             dialect_cls = registry.load(_dialect_kind)
         except:
             dialect_cls = registry.load('postgresql')
-        self.dialect = dialect_cls()
+        self.dialect = dialect_cls(paramstyle='pyformat')
         self.variables = self.refresh_variables()
         self._load_udf_params()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "plaidcloud-utilities"
-version = "1.8.11"
+version = "1.8.12"
 authors = [
     {name = "Michael Rea", email = "mike@plaidcloud.com"},
     {name = "Paul Morel", email = "paul@plaidcloud.com"},


### PR DESCRIPTION
This is because Starrocks default paramstyle is 'format' not 'pyformat' and it upsets us sending query from Workflow Runner to RPC.