### PR TITLE
frame_join_multi: validator + sql_expression helpers + cross-repo fixtures

### DIFF
--- a/plaidcloud/utilities/frame_join_multi_validator.py
+++ b/plaidcloud/utilities/frame_join_multi_validator.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+"""Config validator for the `frame_join_multi` transform step.
+
+Two callers:
+- Plaid `gst.save_object` hook (Layer 1) — runs at every persistence path.
+- workflow-runner executor (Layer 2) — runs at execute time, catches paths that bypass Layer 1
+  (flashback restore via remote RPC, Kube-job-dispatched imports, configs from before this
+  validator was deployed).
+
+Both layers import this same function; it is the single source of truth.
+
+The validator never echoes user input back. Errors carry a stable reason token; the client maps
+the token to a translated message. Reason tokens are listed in `_REASONS` below.
+"""
+
+import json
+import re
+
+__all__ = [
+    'validate_frame_join_multi_config',
+    'JoinMultiValidationError',
+    'OPERATORS',
+    'JOIN_TYPES',
+    'RESERVED_ALIASES',
+]
+
+
+OPERATORS = frozenset({
+    '=', '<>', '<', '<=', '>', '>=',
+    'BETWEEN',
+    'IS NULL', 'IS NOT NULL',
+    'IN', 'NOT IN',
+    'LIKE', 'NOT LIKE',
+})
+
+JOIN_TYPES = frozenset({'inner', 'left', 'full', 'cross'})
+
+RESERVED_ALIASES = frozenset({
+    'result', 'select', 'from', 'where', 'join', 'having', 'group', 'order',
+    'union', 'table', 'inner', 'left', 'right', 'full', 'cross', 'on',
+})
+
+_TABLE_PREFIX_RE = re.compile(r'tab[A-Za-z0-9_-]{1,64}')
+_ALIAS_RE = re.compile(r'[A-Za-z_][A-Za-z0-9_]{0,62}')
+_COLUMN_REF_RE = re.compile(r'[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*')
+_COLUMN_ID_RE = re.compile(r'[A-Za-z_][A-Za-z0-9_]{0,62}')
+
+# Allowed sqlalchemy dtype tokens (per plaidcloud.rpc.type_conversion.sqlalchemy_from_dtype).
+# Closed set keeps the cross-layer contract tight — adding new types requires updating both
+# this set and the dtype mapper.
+_DTYPE_ENUM = frozenset({
+    'text', 'integer', 'bigint', 'smallint', 'tinyint', 'numeric', 'decimal',
+    'float', 'double', 'boolean', 'date', 'timestamp', 'time', 'interval',
+    'json', 'uuid', 'serial', 'bigserial', 'largebinary',
+})
+
+# Allowed aggregation tokens. Anything not in this set would still be accepted by
+# get_agg_fn() via getattr(sqlalchemy.func, ...) and emit a bogus SQL function call.
+_AGG_ENUM = frozenset({
+    'group', 'group_null', 'dont_group',
+    'sum', 'sum_null',
+    'count', 'count_null', 'count_distinct', 'count_distinct_null',
+    'min', 'min_null', 'max', 'max_null',
+    'avg', 'avg_null',
+})
+
+MAX_CONFIG_BYTES = 256 * 1024
+MAX_SOURCES = 32
+MAX_TOTAL_CONDITIONS = 256
+MAX_TARGET_COLUMNS = 1024
+MAX_CONDITIONS_PER_EDGE = 16
+MAX_IN_VALUES = 1000
+MAX_IN_VALUE_BYTES = 1024
+MAX_IN_VALUES_TOTAL_BYTES = 64 * 1024
+MAX_PATTERN_LEN = 256
+
+
+class JoinMultiValidationError(Exception):
+    """Raised when a frame_join_multi config violates a validator rule.
+
+    Carries a stable reason token (`reason`) and a JSONPath-style field locator (`field`).
+    The client maps reason → translated message; the server never echoes user input.
+    """
+
+    def __init__(self, reason: str, field: str = ''):
+        self.code = 'JOIN_VALIDATION'
+        self.reason = reason
+        self.field = field
+        super().__init__(f'{self.code}: {reason} at {field}' if field else f'{self.code}: {reason}')
+
+
+def _err(reason: str, field: str = ''):
+    raise JoinMultiValidationError(reason, field)
+
+
+def validate_frame_join_multi_config(config: dict, dialect: str | None = None) -> None:
+    """Validate a frame_join_multi config dict.
+
+    Raises JoinMultiValidationError on the first violation. Caller catches and translates
+    to whatever exception type their layer needs (HTTPException, UserError, etc.).
+
+    Args:
+        config: The step config dict (the `config` field of a step record, not the whole step).
+        dialect: The tenant's datastore_dialect ('starrocks', 'databend', etc.) for engine-specific
+            rules like FULL OUTER rejection on Databend. None = skip dialect-specific rules
+            (save-time hook doesn't have dialect in scope; executor passes it).
+    """
+    if not isinstance(config, dict):
+        _err('config_not_dict')
+
+    # Shape caps (run first, short-circuit before per-field checks)
+    try:
+        serialized_len = len(json.dumps(config))
+    except (TypeError, ValueError):
+        _err('config_not_json_serializable')
+    if serialized_len > MAX_CONFIG_BYTES:
+        _err('config_too_large')
+
+    sources = config.get('sources')
+    if not isinstance(sources, list):
+        _err('sources_not_list', 'sources')
+    if not (1 <= len(sources) <= MAX_SOURCES):
+        _err('sources_count_out_of_range', 'sources')
+
+    edges = config.get('edges')
+    if not isinstance(edges, list):
+        _err('edges_not_list', 'edges')
+    if len(edges) != len(sources) - 1:
+        _err('edges_count_mismatch', 'edges')
+
+    total_conditions = sum(
+        len(e.get('conditions', [])) for e in edges if isinstance(e, dict)
+    )
+    if total_conditions > MAX_TOTAL_CONDITIONS:
+        _err('too_many_total_conditions', 'edges')
+
+    target_columns = config.get('target_columns', [])
+    if not isinstance(target_columns, list):
+        _err('target_columns_not_list', 'target_columns')
+    if len(target_columns) > MAX_TARGET_COLUMNS:
+        _err('too_many_target_columns', 'target_columns')
+
+    # Sources: alias + source field checks
+    aliases_lower_to_alias: dict[str, str] = {}
+    alias_to_columnset: dict[str, set[str]] = {}
+    for i, s in enumerate(sources):
+        sfield = f'sources[{i}]'
+        if not isinstance(s, dict):
+            _err('source_not_dict', sfield)
+        alias = s.get('alias')
+        if not isinstance(alias, str) or not _ALIAS_RE.fullmatch(alias):
+            _err('alias_invalid', f'{sfield}.alias')
+        if alias.lower() in RESERVED_ALIASES:
+            _err('alias_reserved', f'{sfield}.alias')
+        if alias.lower() in aliases_lower_to_alias:
+            _err('alias_duplicate', f'{sfield}.alias')
+        aliases_lower_to_alias[alias.lower()] = alias
+
+        source = s.get('source')
+        if not isinstance(source, str) or not _TABLE_PREFIX_RE.fullmatch(source):
+            _err('source_not_table_id', f'{sfield}.source')
+
+        source_columns = s.get('source_columns')
+        if not isinstance(source_columns, list):
+            _err('source_columns_not_list', f'{sfield}.source_columns')
+        if len(source_columns) == 0:
+            # A source with zero columns produces invalid SQL (SELECT FROM <table>) — reject.
+            _err('source_columns_empty', f'{sfield}.source_columns')
+        col_names: set[str] = set()
+        for j, c in enumerate(source_columns):
+            if not isinstance(c, dict) or 'id' not in c:
+                _err('source_column_invalid', f'{sfield}.source_columns[{j}]')
+            # Round-8 added isinstance check (TypeError leak); round-9 tightens to regex
+            # match so empty strings, reserved words, identifier-unfriendly characters
+            # ('col with space', '1col', 'order' etc.) don't slip through to SQL emit time.
+            if not isinstance(c['id'], str) or not _COLUMN_ID_RE.fullmatch(c['id']):
+                _err('source_column_invalid', f'{sfield}.source_columns[{j}].id')
+            if c['id'] in col_names:
+                # Duplicate ids silently dedupe in a set but cause sqlalchemy Table-build
+                # failure at SQL emit time. Reject at save (round-7).
+                _err('source_column_duplicate_id', f'{sfield}.source_columns[{j}].id')
+            # dtype: required + closed enum. Round-11 caught that sqlalchemy_from_dtype(None)
+            # raises RegexMapKeyError, and an unvalidated string can mask the actual column
+            # type (e.g., defaulting INTEGER to text produces lexicographic comparison bugs).
+            dtype = c.get('dtype')
+            if not isinstance(dtype, str) or dtype.lower().split('(')[0] not in _DTYPE_ENUM:
+                _err('source_column_dtype_invalid', f'{sfield}.source_columns[{j}].dtype')
+            col_names.add(c['id'])
+        alias_to_columnset[alias] = col_names
+
+    aliases = [s['alias'] for s in sources]
+    aliases_set = set(aliases)
+    root_alias = aliases[0]
+
+    # Edges: shape + tree topology
+    to_aliases_seen: set[str] = set()
+    for i, e in enumerate(edges):
+        efield = f'edges[{i}]'
+        if not isinstance(e, dict):
+            _err('edge_not_dict', efield)
+        from_alias = e.get('from_alias')
+        to_alias = e.get('to_alias')
+        # isinstance guard before `in <set>` lookups — list/dict aliases would raise
+        # TypeError(unhashable) and escalate to HTTP 500 in the catch-all handler. Round-7.
+        if not isinstance(from_alias, str):
+            _err('from_alias_invalid', f'{efield}.from_alias')
+        if not isinstance(to_alias, str):
+            _err('to_alias_invalid', f'{efield}.to_alias')
+        if from_alias not in aliases_set:
+            _err('from_alias_unknown', f'{efield}.from_alias')
+        if to_alias not in aliases_set:
+            _err('to_alias_unknown', f'{efield}.to_alias')
+        if to_alias == root_alias:
+            _err('root_used_as_to_alias', f'{efield}.to_alias')
+        if to_alias in to_aliases_seen:
+            _err('to_alias_duplicate', f'{efield}.to_alias')
+        to_aliases_seen.add(to_alias)
+
+        jt = e.get('join_type')
+        if not isinstance(jt, str):
+            _err('join_type_invalid', f'{efield}.join_type')
+        if jt not in JOIN_TYPES:
+            _err('join_type_invalid', f'{efield}.join_type')
+        if jt == 'full' and dialect == 'databend':
+            _err('full_outer_unsupported_on_dialect', f'{efield}.join_type')
+
+    # Tree connectivity: BFS from root must visit every alias
+    children_by_parent: dict[str, list[str]] = {a: [] for a in aliases}
+    for e in edges:
+        children_by_parent[e['from_alias']].append(e['to_alias'])
+    reachable = {root_alias}
+    queue = [root_alias]
+    while queue:
+        n = queue.pop(0)
+        for c in children_by_parent.get(n, ()):
+            if c in reachable:
+                continue
+            reachable.add(c)
+            queue.append(c)
+    if reachable != aliases_set:
+        _err('tree_not_connected_from_root', 'edges')
+
+    # Conditions per edge
+    for i, e in enumerate(edges):
+        efield = f'edges[{i}]'
+        conditions = e.get('conditions', [])
+        if not isinstance(conditions, list):
+            _err('conditions_not_list', f'{efield}.conditions')
+        jt = e['join_type']
+        if jt == 'cross':
+            if conditions:
+                _err('cross_join_has_conditions', f'{efield}.conditions')
+            continue
+        if not (1 <= len(conditions) <= MAX_CONDITIONS_PER_EDGE):
+            _err('conditions_count_out_of_range', f'{efield}.conditions')
+
+        from_alias = e['from_alias']
+        to_alias = e['to_alias']
+        aliases_seen_in_edge: set[str] = set()
+
+        for j, c in enumerate(conditions):
+            cfield = f'{efield}.conditions[{j}]'
+            if not isinstance(c, dict):
+                _err('condition_not_dict', cfield)
+            op = c.get('operator')
+            # isinstance guard prevents TypeError on `in OPERATORS` if op is list/dict (round-7).
+            if not isinstance(op, str) or op not in OPERATORS:
+                _err('operator_invalid', f'{cfield}.operator')
+
+            left_expr = c.get('left_expr')
+            if not isinstance(left_expr, str) or not _COLUMN_REF_RE.fullmatch(left_expr):
+                _err('left_expr_invalid', f'{cfield}.left_expr')
+            left_alias, left_col = left_expr.split('.', 1)
+            if left_alias not in aliases_set:
+                _err('left_expr_alias_unknown', f'{cfield}.left_expr')
+            if left_col not in alias_to_columnset[left_alias]:
+                _err('left_expr_column_unknown', f'{cfield}.left_expr')
+            aliases_seen_in_edge.add(left_alias)
+
+            # Operator-specific right-side validation
+            if op in ('IS NULL', 'IS NOT NULL'):
+                pass  # right_expr unused
+            elif op in ('IN', 'NOT IN'):
+                _validate_in_values(c.get('in_values'), f'{cfield}.in_values')
+            elif op in ('LIKE', 'NOT LIKE'):
+                _validate_pattern(c.get('pattern'), f'{cfield}.pattern')
+            elif op == 'BETWEEN':
+                _validate_between_bound(c.get('between_low'), aliases_set,
+                                        alias_to_columnset, f'{cfield}.between_low',
+                                        aliases_seen_in_edge)
+                _validate_between_bound(c.get('right_expr'), aliases_set,
+                                        alias_to_columnset, f'{cfield}.right_expr',
+                                        aliases_seen_in_edge)
+            else:
+                # Binary column-to-column operators
+                right_expr = c.get('right_expr')
+                if not isinstance(right_expr, str) or not _COLUMN_REF_RE.fullmatch(right_expr):
+                    _err('right_expr_invalid', f'{cfield}.right_expr')
+                right_alias, right_col = right_expr.split('.', 1)
+                if right_alias not in aliases_set:
+                    _err('right_expr_alias_unknown', f'{cfield}.right_expr')
+                if right_col not in alias_to_columnset[right_alias]:
+                    _err('right_expr_column_unknown', f'{cfield}.right_expr')
+                if right_alias == left_alias:
+                    _err('same_alias_self_compare', cfield)
+                aliases_seen_in_edge.add(right_alias)
+
+        # At least one condition must reference both from_alias and to_alias (binds the edge)
+        if from_alias not in aliases_seen_in_edge or to_alias not in aliases_seen_in_edge:
+            _err('edge_conditions_do_not_bind_aliases', f'{efield}.conditions')
+
+    # Target columns. `source_alias` is required for ALL frame_join_multi configs (no legacy
+    # `source_table: 'table1'|'table2'` fallback). Round-5 caught that allowing the legacy
+    # form for 2-source configs caused silent column-property-propagation loss in the
+    # executor (which filters target_columns by source_alias). Uniform requirement closes that.
+    # Round-11 adds target, dtype, agg, and mode-key checks — every field the executor reads.
+    seen_targets: set[str] = set()
+    for i, tc in enumerate(target_columns):
+        tfield = f'target_columns[{i}]'
+        if not isinstance(tc, dict):
+            _err('target_column_not_dict', tfield)
+
+        # `target`: the OUTPUT column name. Required by get_insert_query and _propagate_column_properties.
+        target_name = tc.get('target')
+        if not isinstance(target_name, str) or not _COLUMN_ID_RE.fullmatch(target_name):
+            _err('target_name_invalid', f'{tfield}.target')
+        if target_name in seen_targets:
+            _err('target_name_duplicate', f'{tfield}.target')
+        seen_targets.add(target_name)
+
+        # `dtype`: required + closed enum. Same rationale as source_columns[*].dtype above.
+        dtype = tc.get('dtype')
+        if not isinstance(dtype, str) or dtype.lower().split('(')[0] not in _DTYPE_ENUM:
+            _err('target_column_dtype_invalid', f'{tfield}.dtype')
+
+        # `agg`: optional, but if set must be a closed-enum string. Anything outside the enum
+        # would cause get_agg_fn to dispatch via getattr(sqlalchemy.func, ...) — arbitrary
+        # SQL function call to a function the engine probably doesn't have.
+        agg = tc.get('agg')
+        if agg is not None and (not isinstance(agg, str) or agg not in _AGG_ENUM):
+            _err('target_column_agg_invalid', f'{tfield}.agg')
+
+        # Mode key: exactly one of (`source` for column-ref, `expression`, `constant`) must be
+        # set — unless dtype is a 'serial'/'bigserial' or magic-column type. `expression` is
+        # NOT allowed in frame_join_multi (it routes through eval_expression which is the
+        # pre-existing P0 risk in source_where/having; this step intentionally doesn't
+        # extend that surface to target columns).
+        if 'expression' in tc and tc.get('expression'):
+            _err('target_column_expression_not_allowed', f'{tfield}.expression')
+        mode_keys = [k for k in ('source', 'constant') if tc.get(k) not in (None, '')]
+        is_magic = dtype.lower() in {'serial', 'bigserial'} if isinstance(dtype, str) else False
+        if not is_magic and len(mode_keys) != 1:
+            _err('target_column_mode_required', tfield)
+
+        source_alias = tc.get('source_alias')
+        # source_alias must be a non-empty string. isinstance check first so we don't leak
+        # TypeError from the `in aliases_set` lookup when given a list/dict (round-6 R6-8).
+        if not isinstance(source_alias, str) or not source_alias:
+            _err('source_alias_required', f'{tfield}.source_alias')
+        if source_alias not in aliases_set:
+            _err('source_alias_unknown', f'{tfield}.source_alias')
+        # Cross-check: the target column's `source` must reference a column that exists in
+        # the chosen alias's source_columns. Round-6 caught the column-existence half; round-7
+        # closes the prefix-mismatch half (silent wrong-result if `source = 'a.col'` but
+        # `source_alias = 'b'` and `col` exists in both aliases — executor emits `b.col`).
+        src_field = tc.get('source')
+        if isinstance(src_field, str) and src_field:
+            # `source` may be `alias.col` or just `col` per existing get_column_table conventions.
+            if '.' in src_field:
+                prefix, col_part = src_field.split('.', 1)
+                if prefix != source_alias:
+                    _err('target_column_source_alias_prefix_mismatch', f'{tfield}.source')
+            else:
+                col_part = src_field
+            if col_part not in alias_to_columnset[source_alias]:
+                _err('target_column_source_not_in_alias', f'{tfield}.source')
+
+    # Per-source source_where validation:
+    #  1. Reject whitespace-only strings (would compile() to empty expression and crash).
+    #  2. Reject cross-source alias-qualified references.
+    # Within-source alias-qualified refs (`<own_alias>.col`) are also rejected because the
+    # executor's eval_expression only exposes the source as `table1`, not by alias — round-12
+    # caught that the validator green-lit a form the executor cannot run. Users should write
+    # `table1.col` (or just `col`) per the binary-join convention.
+    for i, s in enumerate(sources):
+        sw = s.get('source_where')
+        if sw is None:
+            continue
+        if not isinstance(sw, str):
+            _err('source_where_not_string', f'sources[{i}].source_where')
+        if not sw.strip():
+            # Whitespace-only string would crash apply_output_filter/eval_expression with
+            # SyntaxError at execute time. Treat as absent.
+            continue
+        alias = s['alias']
+        for other in aliases:
+            if other == alias:
+                continue
+            pat = re.compile(rf'(?<![A-Za-z0-9_]){re.escape(other)}\.[A-Za-z_]')
+            if pat.search(sw):
+                _err('cross_source_where_ref', f'sources[{i}].source_where')
+        # Reject within-own-source alias-qualified refs that the executor can't resolve.
+        own_pat = re.compile(rf'(?<![A-Za-z0-9_]){re.escape(alias)}\.[A-Za-z_]')
+        if own_pat.search(sw):
+            _err('source_where_alias_qualified_ref', f'sources[{i}].source_where')
+
+    # Having: type-check only. Scope enforcement (`result.<target>` only, no bare names, no
+    # source aliases) happens at execute time in apply_output_filter's eval_expression scope —
+    # an unknown bare name raises NameError → SQLExpressionError → UserError, surfaced to the
+    # user as a friendly message. A save-time scope check would need a real expression parser
+    # to avoid false-positives on string literals; deferred to Phase 2+ if it proves needed.
+    having = config.get('having')
+    if having is not None and not isinstance(having, str):
+        _err('having_not_string', 'having')
+    if isinstance(having, str):
+        if len(having) > 4096:
+            _err('having_too_long', 'having')
+        # Whitespace-only would crash apply_output_filter at execute time (compile of '' raises
+        # SyntaxError outside eval_expression's try/except). Round-12 caught it persisting
+        # across multiple rounds — close it at the validator.
+        if having and not having.strip():
+            _err('having_empty_or_whitespace', 'having')
+        # Reject having referencing target columns that don't exist (round-13).
+        # apply_output_filter exposes `result.<target_name>`; an unknown target would raise
+        # AttributeError at execute time. Catching at save time gives a friendly reason.
+        if having and having.strip():
+            for m in re.finditer(r'(?<![A-Za-z0-9_])result\.([A-Za-z_][A-Za-z0-9_]*)', having):
+                if m.group(1) not in seen_targets:
+                    _err('having_references_unknown_target', 'having')
+                    break
+
+    # output_row_limit: user-controlled soft ceiling for the cartesian guard. Cap it server-side
+    # so a malicious config can't set it to 499B and bypass the guard up to the hard limit.
+    output_row_limit = config.get('output_row_limit')
+    if output_row_limit is not None:
+        if not isinstance(output_row_limit, int) or isinstance(output_row_limit, bool):
+            _err('output_row_limit_not_int', 'output_row_limit')
+        if output_row_limit < 1 or output_row_limit > 10_000_000_000:
+            _err('output_row_limit_out_of_range', 'output_row_limit')
+
+    # target_frame: the destination table id. Required by the executor's get_frame() call.
+    # Validator round-11 closed the gap (was unchecked).
+    target_frame = config.get('target_frame')
+    if not isinstance(target_frame, str) or not _TABLE_PREFIX_RE.fullmatch(target_frame):
+        _err('target_frame_invalid', 'target_frame')
+
+    # datastore_dialect: derived server-side from tenant context, NOT user config. Save-time
+    # callers (dialect=None) reject any user-supplied value to prevent bypassing engine-specific
+    # rules. Execute-time callers (dialect != None) accept whatever's there since the framework
+    # has already merged in the tenant-trusted dialect. Validator round-11 closed this bypass.
+    if dialect is None and 'datastore_dialect' in config:
+        _err('datastore_dialect_not_user_settable', 'datastore_dialect')
+
+
+def _validate_in_values(in_values, field):
+    if not isinstance(in_values, list):
+        _err('in_values_not_list', field)
+    if not (1 <= len(in_values) <= MAX_IN_VALUES):
+        _err('in_values_count_out_of_range', field)
+    total = 0
+    for k, v in enumerate(in_values):
+        if not isinstance(v, (str, int, float, bool)) and v is not None:
+            _err('in_value_not_primitive', f'{field}[{k}]')
+        try:
+            elem_len = len(json.dumps(v))
+        except (TypeError, ValueError):
+            _err('in_value_not_serializable', f'{field}[{k}]')
+        if elem_len > MAX_IN_VALUE_BYTES:
+            _err('in_value_too_large', f'{field}[{k}]')
+        total += elem_len
+    if total > MAX_IN_VALUES_TOTAL_BYTES:
+        _err('in_values_total_too_large', field)
+
+
+def _validate_pattern(pattern, field):
+    if not isinstance(pattern, str):
+        _err('pattern_not_string', field)
+    if len(pattern) > MAX_PATTERN_LEN:
+        _err('pattern_too_long', field)
+
+
+def _validate_between_bound(bound, aliases_set, alias_to_columnset, field, aliases_seen_in_edge):
+    """A BETWEEN bound is either a column ref (alias.col) or a primitive literal."""
+    if isinstance(bound, str):
+        if _COLUMN_REF_RE.fullmatch(bound):
+            alias, col = bound.split('.', 1)
+            if alias not in aliases_set:
+                _err('between_bound_alias_unknown', field)
+            if col not in alias_to_columnset[alias]:
+                _err('between_bound_column_unknown', field)
+            aliases_seen_in_edge.add(alias)
+            return
+        # else treat as a string literal — allowed
+        if len(bound) > MAX_IN_VALUE_BYTES:
+            _err('between_bound_string_too_long', field)
+        return
+    if isinstance(bound, (int, float, bool)) or bound is None:
+        return
+    _err('between_bound_invalid', field)
+
+

--- a/plaidcloud/utilities/sql_expression.py
+++ b/plaidcloud/utilities/sql_expression.py
@@ -126,36 +126,85 @@ def on_clause(table_a: sqlalchemy.Table, table_b: sqlalchemy.Table, join_map: li
     ])
 
 
-def get_column_table(source_tables: list[sqlalchemy.Table], target_column_config: dict, source_column_configs: list[list[dict]], table_numbering_start: int = 1):
-    """Find the source table associated with a column."""
+def get_column_table(
+    source_tables: list[sqlalchemy.Table],
+    target_column_config: dict,
+    source_column_configs: list[list[dict]],
+    table_numbering_start: int = 1,
+    *,
+    tables_by_alias: dict | None = None,
+):
+    """Find the source table associated with a column.
+
+    Precedence:
+        1. `source_alias` in target_column_config → look up in `tables_by_alias`.
+           Requires `tables_by_alias` to be passed; raises if alias not found.
+        2. Legacy `source_table: 'table1'|'table2'` AND len(source_tables) == 2 → positional.
+           Rejected when len(source_tables) > 2 (use source_alias instead).
+        3. `source_name` matches `tableN.col` → positional (existing behavior).
+        4. Name-intersect fallback: search source_column_configs. For len(source_tables) > 2,
+           rejects on ambiguity (column name in multiple sources). For len <= 2, returns
+           the first match (existing behavior, preserves binary-join backward compat).
+
+    Args:
+        tables_by_alias: keyword-only. Required when `source_alias` is used. None by default
+            so existing callers (which pass only positional `tables`) keep working unchanged.
+    """
 
     if len(source_tables) == 1:  # Shortcut for most simple cases
         return source_tables[0]
 
+    # Rule 1: explicit source_alias (new for frame_join_multi)
+    source_alias = target_column_config.get('source_alias')
+    if source_alias:
+        if tables_by_alias is None:
+            raise SQLExpressionError(
+                f"target_column references source_alias={source_alias!r} but tables_by_alias was not provided"
+            )
+        if source_alias not in tables_by_alias:
+            raise SQLExpressionError(
+                f"target_column source_alias={source_alias!r} not found in sources"
+            )
+        return tables_by_alias[source_alias]
+
+    # Rule 2: legacy source_table for binary joins
     if target_column_config.get('source_table'):
+        if len(source_tables) > 2:
+            raise SQLExpressionError(
+                "source_table='tableN' is only valid for 2-table joins; use source_alias instead"
+            )
         if target_column_config['source_table'].lower() in ('table a', 'table1'):
             return source_tables[0]
         if target_column_config['source_table'].lower() in ('table b', 'table2'):
             return source_tables[1]
 
-    source_name = target_column_config['source']
+    source_name = target_column_config.get('source')
 
-    match = table_dot_column_regex.match(source_name)
-    if match:  # They gave us a table number. Subtract 1 to find it's index
-        if source_name.startswith('table.'):  # special case for just 'table'
-            return source_tables[0]
+    # Rule 3: positional tableN.col reference
+    if source_name:
+        match = table_dot_column_regex.match(source_name)
+        if match:
+            if source_name.startswith('table.'):
+                return source_tables[0]
+            table_number = int(match.groups()[0])
+            return source_tables[table_number - table_numbering_start]
 
-        table_number = int(match.groups()[0])
-        return source_tables[table_number - table_numbering_start]
-
-    # None of our shortcuts worked, so look for the first table to have a
-    # column of that name.
+    # Rule 4: name-intersect fallback
+    matches = []
     for table, columns in zip(source_tables, source_column_configs):
         columnset = {c['source'] for c in columns}
         if source_name in columnset:
-            return table
+            matches.append(table)
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1 and len(source_tables) > 2:
+        raise SQLExpressionError(
+            f"Column {source_name!r} exists in multiple sources; set source_alias explicitly"
+        )
+    if matches:
+        # 2 sources, column in both — preserve existing first-match behavior
+        return matches[0]
 
-    # If nothing found at all:
     raise SQLExpressionError(f"Mapped source column {source_name} is not in any source tables.")
 
 
@@ -220,9 +269,13 @@ def expression_from_clause(expression: str, tables: list[sqlalchemy.Table], sort
     return process_fn(sort_type, cast_type, agg_type, name, trim_zeroes)(expr)
 
 # TODO: write tests, though TestGetFromClause already covers this
-def source_from_clause(source: str, tables: list[sqlalchemy.Table], target_column_config: dict, source_column_configs: list[list[dict]], cast: bool, sort_type: bool|None, cast_type: type[sqlalchemy.types.TypeEngine]|None, agg_type: str|None, name: str, table_numbering_start: int = 1, trim_zeroes: bool = False):
+def source_from_clause(source: str, tables: list[sqlalchemy.Table], target_column_config: dict, source_column_configs: list[list[dict]], cast: bool, sort_type: bool|None, cast_type: type[sqlalchemy.types.TypeEngine]|None, agg_type: str|None, name: str, table_numbering_start: int = 1, trim_zeroes: bool = False, *, tables_by_alias: dict | None = None):
     """Get a representation of a target column based on a source column."""
-    table = get_column_table(tables, target_column_config, source_column_configs, table_numbering_start=table_numbering_start)
+    table = get_column_table(
+        tables, target_column_config, source_column_configs,
+        table_numbering_start=table_numbering_start,
+        tables_by_alias=tables_by_alias,
+    )
 
     if '.' in source:
         source_without_table = source.split('.', 1)[1]
@@ -251,7 +304,8 @@ def source_from_clause(source: str, tables: list[sqlalchemy.Table], target_colum
 def get_from_clause(
     tables: list[sqlalchemy.Table], target_column_config: dict, source_column_configs: list[list[dict]], aggregate: bool = False,
     sort: bool = False, variables: dict = None, cast: bool = True, disable_variables: bool = False, table_numbering_start: int = 1,
-    sort_columns: list = None, use_row_number_for_serial: bool = True, trim_zeroes: bool = False
+    sort_columns: list = None, use_row_number_for_serial: bool = True, trim_zeroes: bool = False,
+    *, tables_by_alias: dict | None = None,
 ):
     """Given info from a config, returns a sqlalchemy expression representing a single target column."""
 
@@ -277,7 +331,7 @@ def get_from_clause(
     if expression:
         return expression_from_clause(expression, tables, sort_type, cast_type, agg_type, name, variables, disable_variables, table_numbering_start, trim_zeroes)
     if source:
-        return source_from_clause(source, tables, target_column_config, source_column_configs, cast, sort_type, cast_type, agg_type, name, table_numbering_start, trim_zeroes)
+        return source_from_clause(source, tables, target_column_config, source_column_configs, cast, sort_type, cast_type, agg_type, name, table_numbering_start, trim_zeroes, tables_by_alias=tables_by_alias)
     if target_column_config.get('dtype') in {'serial', 'bigserial'}:
         if use_row_number_for_serial:
             return process_fn(sort_type, cast_type, agg_type, name, trim_zeroes)(sqlalchemy.func.row_number().over(order_by=sort_columns or []))
@@ -533,7 +587,8 @@ def get_select_query(
     config: dict = None, variables: dict = None, aggregate: bool = None, having: str = None,
     use_target_slicer: bool = None, limit_target_start: int = None, limit_target_end: int = None,
     distinct: bool = None, count: bool = None, disable_variables: bool = None, table_numbering_start: int = 1,
-    use_row_number_for_serial: bool = True, aggregation_type: str = 'group', cast: bool = True, trim_zeroes: bool = False
+    use_row_number_for_serial: bool = True, aggregation_type: str = 'group', cast: bool = True, trim_zeroes: bool = False,
+    *, tables_by_alias: dict | None = None,
 ):
     """Returns a sqlalchemy select query from table objects and an extract
     config (or from the individual parameters in that config). tables,
@@ -607,7 +662,8 @@ def get_select_query(
                 variables=variables,
                 disable_variables=disable_variables,
                 table_numbering_start=table_numbering_start,
-                cast=cast
+                cast=cast,
+                tables_by_alias=tables_by_alias,
             )
             for tc in sort_order
         ]
@@ -631,6 +687,7 @@ def get_select_query(
                 use_row_number_for_serial=use_row_number_for_serial,
                 cast=cast,
                 trim_zeroes=trim_zeroes,
+                tables_by_alias=tables_by_alias,
             )
             for tc in target_columns
             if (use_row_number_for_serial or tc['dtype'] not in ('serial', 'bigserial'))
@@ -664,6 +721,7 @@ def get_select_query(
                 table_numbering_start=table_numbering_start,
                 use_row_number_for_serial=use_row_number_for_serial,
                 trim_zeroes=trim_zeroes,
+                tables_by_alias=tables_by_alias,
             )
             for tc in target_columns
             if (
@@ -1270,3 +1328,187 @@ def apply_rules(source_query, df_rules, rule_id_column, target_columns=None, inc
     )
 
     return cte_rules, final_select
+
+
+# ---------------------------------------------------------------------------
+# frame_join_multi helpers
+#
+# These are imported by the workflow-runner executor for the `frame_join_multi`
+# transform. They are also imported by plaid's save-time validator hook for
+# config validation. See PLAN_multi_table_join_step.md for full design.
+# ---------------------------------------------------------------------------
+
+_FJM_COLUMN_REF_RE = re.compile(r'[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*')
+
+
+def _fjm_resolve_column(expr: str, tables_by_alias: dict) -> sqlalchemy.ColumnElement:
+    """Resolve an `alias.column` string to a sqlalchemy column.
+
+    Caller is responsible for having validated `expr` matches the column-ref regex.
+    Raises SQLExpressionError if alias or column is missing (or expr is malformed).
+    """
+    # Defense in depth — the validator's regex enforces the dot, but bypass paths
+    # (flashback restore of pre-validator configs, hand-edited configs) could reach here
+    # with a no-dot string; tuple unpacking on `split` would raise ValueError otherwise.
+    if '.' not in expr:
+        raise SQLExpressionError(f"edge predicate column reference missing alias prefix: {expr!r}")
+    alias, col = expr.split('.', 1)
+    if alias not in tables_by_alias:
+        raise SQLExpressionError(f"edge predicate references unknown alias {alias!r}")
+    table = tables_by_alias[alias]
+    if col not in table.columns:
+        raise SQLExpressionError(f"edge predicate references unknown column {alias}.{col}")
+    return table.columns[col]
+
+
+def _fjm_resolve_bound(value, tables_by_alias: dict):
+    """A BETWEEN bound is either a column reference (alias.col) or a primitive literal."""
+    if isinstance(value, str) and _FJM_COLUMN_REF_RE.fullmatch(value):
+        return _fjm_resolve_column(value, tables_by_alias)
+    return sqlalchemy.literal(value)
+
+
+def edge_predicate(edge: dict, tables_by_alias: dict, dialect: str | None = None) -> sqlalchemy.ColumnElement:
+    """Build a sqlalchemy predicate from a frame_join_multi edge's conditions.
+
+    Returns an AND of the per-condition predicates. Caller (the executor) is responsible
+    for using this as the ON clause of a JOIN / OUTERJOIN. Callers must NOT pass `expr`-mode
+    or any operator outside the closed 13-op set — the validator rejects those at save time
+    and the executor re-runs the validator, so this function may assume well-formed input.
+
+    All user-supplied literals (`pattern`, `in_values`, `between_low`, scalar `right_expr`) are
+    bound via `sqlalchemy.literal(...)` so they become parameterized binds. Nothing in this
+    function calls `text()`, `eval`, or string-formats user input into SQL.
+
+    Args:
+        edge: dict with `conditions` (list of {operator, left_expr, ...}).
+        tables_by_alias: maps `alias` to a sqlalchemy `Table` or `Subquery` whose `.columns`
+            attribute exposes named columns.
+        dialect: reserved for future dialect-specific dispatch; unused today (all 13 operators
+            compile the same way on StarRocks and Databend).
+    """
+    if dialect is not None:
+        # Currently no operator in the 13-op set needs dialect dispatch. Keep the arg for the
+        # future (e.g., if <=> NULL-safe equality is added back, Databend may need emulation).
+        pass
+
+    predicates = []
+    for c in edge.get('conditions', []):
+        op = c['operator']
+        left = _fjm_resolve_column(c['left_expr'], tables_by_alias)
+
+        if op == '=':
+            predicates.append(left == _fjm_resolve_column(c['right_expr'], tables_by_alias))
+        elif op == '<>':
+            predicates.append(left != _fjm_resolve_column(c['right_expr'], tables_by_alias))
+        elif op == '<':
+            predicates.append(left < _fjm_resolve_column(c['right_expr'], tables_by_alias))
+        elif op == '<=':
+            predicates.append(left <= _fjm_resolve_column(c['right_expr'], tables_by_alias))
+        elif op == '>':
+            predicates.append(left > _fjm_resolve_column(c['right_expr'], tables_by_alias))
+        elif op == '>=':
+            predicates.append(left >= _fjm_resolve_column(c['right_expr'], tables_by_alias))
+        elif op == 'IS NULL':
+            predicates.append(left.is_(None))
+        elif op == 'IS NOT NULL':
+            predicates.append(left.isnot(None))
+        elif op == 'IN':
+            predicates.append(left.in_([sqlalchemy.literal(v) for v in c['in_values']]))
+        elif op == 'NOT IN':
+            predicates.append(~left.in_([sqlalchemy.literal(v) for v in c['in_values']]))
+        elif op == 'LIKE':
+            predicates.append(left.like(sqlalchemy.literal(c['pattern'])))
+        elif op == 'NOT LIKE':
+            predicates.append(~left.like(sqlalchemy.literal(c['pattern'])))
+        elif op == 'BETWEEN':
+            low = _fjm_resolve_bound(c['between_low'], tables_by_alias)
+            high = _fjm_resolve_bound(c['right_expr'], tables_by_alias)
+            predicates.append(left.between(low, high))
+        else:
+            raise SQLExpressionError(f"edge predicate: unsupported operator {op!r}")
+
+    return sqlalchemy.and_(*predicates)
+
+
+def topo_sort_edges(edges: list[dict], root: str) -> list[dict]:
+    """Return edges in BFS-discovery order from `root`.
+
+    The validator guarantees a valid tree (no cycles, no diamonds, every alias reachable),
+    so this is a straightforward BFS. The executor's tree-fold loop requires `from_alias` of
+    each edge to already be in the joined accumulator — topo order from root guarantees this.
+
+    Defense in depth: the validator already asserts tree validity. This function tolerates
+    out-of-order YAML / hand-edited configs by re-deriving the order; it would raise only
+    if the validator was bypassed and the tree is malformed.
+    """
+    edges_by_from: dict[str, list[dict]] = {}
+    for e in edges:
+        edges_by_from.setdefault(e['from_alias'], []).append(e)
+
+    visited = {root}
+    queue = [root]
+    ordered: list[dict] = []
+    while queue:
+        node = queue.pop(0)
+        for e in edges_by_from.get(node, ()):
+            if e['to_alias'] in visited:
+                raise SQLExpressionError(
+                    f"topo_sort_edges: cycle or diamond detected at edge to {e['to_alias']!r}"
+                )
+            visited.add(e['to_alias'])
+            queue.append(e['to_alias'])
+            ordered.append(e)
+
+    if len(ordered) != len(edges):
+        raise SQLExpressionError(
+            f"topo_sort_edges: {len(edges) - len(ordered)} edges unreachable from root {root!r}"
+        )
+    return ordered
+
+
+def check_cartesian_explosion(
+    sources: list[dict],
+    edges: list[dict],
+    row_count_fn,
+    row_limit: int,
+    hard_limit: int = 500_000_000_000,
+) -> None:
+    """Walk the join tree and reject if cross-joins or zero-condition edges produce too many rows.
+
+    Mirrors `workflow-runner/frame_join_inner.py:65-98` for binary inner joins, extended to N tables.
+    For any edge where the cumulative cartesian product would exceed the limit, raises
+    SQLExpressionError with a clear message. Validator-side rules (zero conditions only allowed
+    for `cross`) already ensure most cartesian risks are explicit.
+
+    Args:
+        sources: list of {alias, source} dicts from config.
+        edges: list of edges (any order; topo-sorted internally).
+        row_count_fn: callable(table_id) -> int. Caller (executor) wraps
+            `self.rpc.analyze.table.table(...).get('row_count', 0)`. Tests pass a mock.
+        row_limit: per-step soft limit; raises if cumulative exceeds this.
+        hard_limit: absolute ceiling; raises regardless of caller-specified row_limit.
+
+    Raises:
+        SQLExpressionError with message naming the offending edge.
+    """
+    limit = min(row_limit, hard_limit)
+    row_counts_by_alias = {s['alias']: row_count_fn(s['source']) or 0 for s in sources}
+    ordered = topo_sort_edges(edges, sources[0]['alias'])
+
+    cumulative = row_counts_by_alias[sources[0]['alias']]
+    for e in ordered:
+        child_rows = row_counts_by_alias[e['to_alias']]
+        # For non-cross joins with conditions, the executor's predicate filters down; we can't
+        # statically estimate the post-predicate cardinality. We only flag cross / zero-condition
+        # edges where the product is the actual upper bound the engine will see.
+        is_unbounded = (e['join_type'] == 'cross') or not e.get('conditions')
+        if is_unbounded:
+            cumulative *= max(child_rows, 1)
+            if cumulative > limit:
+                raise SQLExpressionError(
+                    f"cartesian explosion: cross/unfiltered join at edge "
+                    f"{e['from_alias']!r} -> {e['to_alias']!r} would produce "
+                    f"{cumulative} rows, exceeding limit {limit}"
+                )
+        # For filtered joins, we don't update cumulative (predicates make the estimate meaningless).

--- a/plaidcloud/utilities/test_fixtures/frame_join_multi_config_fixtures.json
+++ b/plaidcloud/utilities/test_fixtures/frame_join_multi_config_fixtures.json
@@ -1,0 +1,1484 @@
+{
+  "_comment": "Cross-repo fixtures for frame_join_multi validator + executor. Imported via importlib.resources.files('plaidcloud.utilities.test_fixtures'). Each top-level key is a fixture name; 'valid' fixtures must pass validate_frame_join_multi_config; 'invalid_*' fixtures must raise JoinMultiValidationError with the documented reason token.",
+  "valid_two_source_inner": {
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "sales",
+        "source": "tabSales01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "customer_id",
+            "dtype": "text"
+          },
+          {
+            "id": "total",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "cust",
+        "source": "tabCust01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "name",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "sales",
+        "to_alias": "cust",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "sales.customer_id",
+            "operator": "=",
+            "right_expr": "cust.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [
+      {
+        "source_alias": "sales",
+        "source": "sales.id",
+        "target": "sale_id",
+        "dtype": "integer"
+      },
+      {
+        "source_alias": "cust",
+        "source": "cust.name",
+        "target": "customer",
+        "dtype": "text"
+      }
+    ],
+    "target_frame": "tabOut01"
+  },
+  "valid_three_source_tree": {
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "sales",
+        "source": "tabSales01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "customer_id",
+            "dtype": "text"
+          },
+          {
+            "id": "product_id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "cust",
+        "source": "tabCust01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "name",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "prod",
+        "source": "tabProd01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "title",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "sales",
+        "to_alias": "cust",
+        "join_type": "left",
+        "conditions": [
+          {
+            "left_expr": "sales.customer_id",
+            "operator": "=",
+            "right_expr": "cust.id"
+          }
+        ]
+      },
+      {
+        "from_alias": "sales",
+        "to_alias": "prod",
+        "join_type": "left",
+        "conditions": [
+          {
+            "left_expr": "sales.product_id",
+            "operator": "=",
+            "right_expr": "prod.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [
+      {
+        "source_alias": "sales",
+        "source": "sales.id",
+        "target": "sale_id",
+        "dtype": "integer"
+      },
+      {
+        "source_alias": "cust",
+        "source": "cust.name",
+        "target": "customer",
+        "dtype": "text"
+      },
+      {
+        "source_alias": "prod",
+        "source": "prod.title",
+        "target": "product",
+        "dtype": "text"
+      }
+    ],
+    "target_frame": "tabOut01"
+  },
+  "valid_five_source_mixed_joins": {
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "a",
+        "source": "tabA01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "b_id",
+            "dtype": "text"
+          },
+          {
+            "id": "c_id",
+            "dtype": "text"
+          },
+          {
+            "id": "amt",
+            "dtype": "text"
+          },
+          {
+            "id": "dt",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "b",
+        "source": "tabB01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "name",
+            "dtype": "text"
+          },
+          {
+            "id": "score",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "c",
+        "source": "tabC01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "d_id",
+            "dtype": "text"
+          },
+          {
+            "id": "label",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "d",
+        "source": "tabD01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "tag",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "e",
+        "source": "tabE01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "a_id",
+            "dtype": "text"
+          },
+          {
+            "id": "category",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "a",
+        "to_alias": "b",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "a.b_id",
+            "operator": "=",
+            "right_expr": "b.id"
+          }
+        ]
+      },
+      {
+        "from_alias": "a",
+        "to_alias": "c",
+        "join_type": "left",
+        "conditions": [
+          {
+            "left_expr": "a.c_id",
+            "operator": "=",
+            "right_expr": "c.id"
+          },
+          {
+            "left_expr": "a.amt",
+            "operator": ">",
+            "right_expr": "c.id"
+          }
+        ]
+      },
+      {
+        "from_alias": "c",
+        "to_alias": "d",
+        "join_type": "left",
+        "conditions": [
+          {
+            "left_expr": "c.d_id",
+            "operator": "=",
+            "right_expr": "d.id"
+          }
+        ]
+      },
+      {
+        "from_alias": "a",
+        "to_alias": "e",
+        "join_type": "full",
+        "conditions": [
+          {
+            "left_expr": "a.id",
+            "operator": "=",
+            "right_expr": "e.a_id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [
+      {
+        "source_alias": "a",
+        "source": "a.id",
+        "target": "a_id",
+        "dtype": "integer"
+      },
+      {
+        "source_alias": "b",
+        "source": "b.name",
+        "target": "b_name",
+        "dtype": "text"
+      },
+      {
+        "source_alias": "c",
+        "source": "c.label",
+        "target": "c_label",
+        "dtype": "text"
+      },
+      {
+        "source_alias": "d",
+        "source": "d.tag",
+        "target": "d_tag",
+        "dtype": "text"
+      },
+      {
+        "source_alias": "e",
+        "source": "e.category",
+        "target": "e_category",
+        "dtype": "text"
+      }
+    ],
+    "target_frame": "tabOut01"
+  },
+  "valid_all_operators": {
+    "_doc": "Exercises every one of the 13 operators across multiple edges.",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "a",
+        "source": "tabA01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "amt",
+            "dtype": "text"
+          },
+          {
+            "id": "name",
+            "dtype": "text"
+          },
+          {
+            "id": "dt",
+            "dtype": "text"
+          },
+          {
+            "id": "low",
+            "dtype": "text"
+          },
+          {
+            "id": "high",
+            "dtype": "text"
+          },
+          {
+            "id": "code",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "b",
+        "source": "tabB01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "amt",
+            "dtype": "text"
+          },
+          {
+            "id": "name",
+            "dtype": "text"
+          },
+          {
+            "id": "dt",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "a",
+        "to_alias": "b",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "a.id",
+            "operator": "=",
+            "right_expr": "b.id"
+          },
+          {
+            "left_expr": "a.amt",
+            "operator": "<>",
+            "right_expr": "b.amt"
+          },
+          {
+            "left_expr": "a.amt",
+            "operator": "<",
+            "right_expr": "b.amt"
+          },
+          {
+            "left_expr": "a.amt",
+            "operator": "<=",
+            "right_expr": "b.amt"
+          },
+          {
+            "left_expr": "a.amt",
+            "operator": ">",
+            "right_expr": "b.amt"
+          },
+          {
+            "left_expr": "a.amt",
+            "operator": ">=",
+            "right_expr": "b.amt"
+          },
+          {
+            "left_expr": "a.name",
+            "operator": "IS NULL"
+          },
+          {
+            "left_expr": "a.name",
+            "operator": "IS NOT NULL"
+          },
+          {
+            "left_expr": "a.code",
+            "operator": "IN",
+            "in_values": [
+              "x",
+              "y",
+              "z"
+            ]
+          },
+          {
+            "left_expr": "a.code",
+            "operator": "NOT IN",
+            "in_values": [
+              "q"
+            ]
+          },
+          {
+            "left_expr": "a.name",
+            "operator": "LIKE",
+            "pattern": "%foo%"
+          },
+          {
+            "left_expr": "a.name",
+            "operator": "NOT LIKE",
+            "pattern": "_bar"
+          },
+          {
+            "left_expr": "a.amt",
+            "operator": "BETWEEN",
+            "between_low": 10,
+            "right_expr": 100
+          }
+        ]
+      }
+    ],
+    "target_columns": [
+      {
+        "source_alias": "a",
+        "source": "a.id",
+        "target": "id",
+        "dtype": "integer"
+      },
+      {
+        "source_alias": "b",
+        "source": "b.name",
+        "target": "b_name",
+        "dtype": "text"
+      }
+    ],
+    "target_frame": "tabOut01"
+  },
+  "invalid_legacy_source_table_rejected": {
+    "_doc": "frame_join_multi rejects legacy source_table='table1'/'table2' uniformly. Per round-5 SQL F1 fix, source_alias is required for all multi-join target columns to avoid silent column-property-propagation loss.",
+    "_expected_reason": "source_alias_required",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "sales",
+        "source": "tabSales01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "customer_id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "cust",
+        "source": "tabCust01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "name",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "sales",
+        "to_alias": "cust",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "sales.customer_id",
+            "operator": "=",
+            "right_expr": "cust.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [
+      {
+        "source_table": "table1",
+        "source": "id",
+        "target": "sale_id",
+        "dtype": "integer"
+      },
+      {
+        "source_table": "table2",
+        "source": "name",
+        "target": "customer",
+        "dtype": "text"
+      }
+    ],
+    "target_frame": "tabOut01"
+  },
+  "valid_cross_join": {
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "a",
+        "source": "tabA01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "b",
+        "source": "tabB01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "a",
+        "to_alias": "b",
+        "join_type": "cross",
+        "conditions": []
+      }
+    ],
+    "target_columns": [
+      {
+        "source_alias": "a",
+        "source": "a.id",
+        "target": "a_id",
+        "dtype": "integer"
+      },
+      {
+        "source_alias": "b",
+        "source": "b.id",
+        "target": "b_id",
+        "dtype": "integer"
+      }
+    ],
+    "target_frame": "tabOut01"
+  },
+  "invalid_root_used_as_to_alias": {
+    "_doc": "2-source cycle: a is root but appears as to_alias. (A full multi-edge cycle is structurally prevented by the edge-count rule, since cycles need >= N edges and trees have exactly N-1.)",
+    "_expected_reason": "root_used_as_to_alias",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "a",
+        "source": "tabA01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "b",
+        "source": "tabB01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "b",
+        "to_alias": "a",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "b.id",
+            "operator": "=",
+            "right_expr": "a.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "invalid_diamond": {
+    "_doc": "4 sources, 3 edges (matches count rule), where d is to_alias of two edges. c is orphan but to_alias_duplicate fires first.",
+    "_expected_reason": "to_alias_duplicate",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "a",
+        "source": "tabA01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "b",
+        "source": "tabB01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "c",
+        "source": "tabC01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "d",
+        "source": "tabD01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "a",
+        "to_alias": "b",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "a.id",
+            "operator": "=",
+            "right_expr": "b.id"
+          }
+        ]
+      },
+      {
+        "from_alias": "b",
+        "to_alias": "d",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "b.id",
+            "operator": "=",
+            "right_expr": "d.id"
+          }
+        ]
+      },
+      {
+        "from_alias": "c",
+        "to_alias": "d",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "c.id",
+            "operator": "=",
+            "right_expr": "d.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "invalid_edges_count_mismatch_too_many": {
+    "_doc": "More edges than sources-1 \u2014 proper cycle is impossible without violating count, so count rule catches it.",
+    "_expected_reason": "edges_count_mismatch",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "a",
+        "source": "tabA01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "b",
+        "source": "tabB01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "a",
+        "to_alias": "b",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "a.id",
+            "operator": "=",
+            "right_expr": "b.id"
+          }
+        ]
+      },
+      {
+        "from_alias": "a",
+        "to_alias": "b",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "a.id",
+            "operator": "=",
+            "right_expr": "b.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "invalid_orphan_source": {
+    "_doc": "Three sources but only one edge \u2014 second source unreachable from root.",
+    "_expected_reason": "edges_count_mismatch",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "a",
+        "source": "tabA01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "b",
+        "source": "tabB01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "c",
+        "source": "tabC01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "a",
+        "to_alias": "b",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "a.id",
+            "operator": "=",
+            "right_expr": "b.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "invalid_alias_reserved": {
+    "_expected_reason": "alias_reserved",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "result",
+        "source": "tabA01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "b",
+        "source": "tabB01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "result",
+        "to_alias": "b",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "result.id",
+            "operator": "=",
+            "right_expr": "b.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "invalid_alias_duplicate": {
+    "_expected_reason": "alias_duplicate",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "x",
+        "source": "tabA01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "x",
+        "source": "tabB01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "x",
+        "to_alias": "x",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "x.id",
+            "operator": "=",
+            "right_expr": "x.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "invalid_source_not_table_id": {
+    "_doc": "source must be TABLE_PREFIX-prefixed UUID; path-style values rejected.",
+    "_expected_reason": "source_not_table_id",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "a",
+        "source": "folder/path/to/table",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "invalid_source_with_format_chars": {
+    "_doc": "source containing { triggers str.format injection in apply_variables. Rejected.",
+    "_expected_reason": "source_not_table_id",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "a",
+        "source": "tab{secret}",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "invalid_cross_with_conditions": {
+    "_expected_reason": "cross_join_has_conditions",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "a",
+        "source": "tabA01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "b",
+        "source": "tabB01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "a",
+        "to_alias": "b",
+        "join_type": "cross",
+        "conditions": [
+          {
+            "left_expr": "a.id",
+            "operator": "=",
+            "right_expr": "b.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "invalid_left_expr_alias_self_compare": {
+    "_doc": "left_expr and right_expr both reference the same alias (sales.id = sales.id). Tautological cross product hidden as a condition.",
+    "_expected_reason": "same_alias_self_compare",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "sales",
+        "source": "tabSales01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "cust",
+        "source": "tabCust01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "sales",
+        "to_alias": "cust",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "sales.id",
+            "operator": "=",
+            "right_expr": "sales.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "invalid_edge_conditions_do_not_bind_aliases": {
+    "_doc": "Edge sales->cust has a condition that doesn't reference cust at all.",
+    "_expected_reason": "edge_conditions_do_not_bind_aliases",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "sales",
+        "source": "tabSales01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "x",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "cust",
+        "source": "tabCust01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "prod",
+        "source": "tabProd01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "sales",
+        "to_alias": "cust",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "sales.id",
+            "operator": "=",
+            "right_expr": "prod.id"
+          }
+        ]
+      },
+      {
+        "from_alias": "sales",
+        "to_alias": "prod",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "sales.x",
+            "operator": "=",
+            "right_expr": "prod.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "invalid_having_too_long": {
+    "_doc": "having > 4096 chars rejected. Test does not include the giant string; the test code constructs it.",
+    "_expected_reason": "having_too_long",
+    "_runtime_synth": "having_oversize",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "a",
+        "source": "tabA01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "invalid_in_values_count": {
+    "_expected_reason": "in_values_count_out_of_range",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "a",
+        "source": "tabA01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "b",
+        "source": "tabB01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "a",
+        "to_alias": "b",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "a.id",
+            "operator": "IN",
+            "in_values": [],
+            "right_expr": "b.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "invalid_source_alias_required_when_n_gt_2": {
+    "_doc": "target_column omits source_alias \u2014 required for all frame_join_multi configs regardless of n_sources (round-5 fix).",
+    "_expected_reason": "source_alias_required",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "a",
+        "source": "tabA01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "b_id",
+            "dtype": "text"
+          },
+          {
+            "id": "c_id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "b",
+        "source": "tabB01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "c",
+        "source": "tabC01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "a",
+        "to_alias": "b",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "a.b_id",
+            "operator": "=",
+            "right_expr": "b.id"
+          }
+        ]
+      },
+      {
+        "from_alias": "a",
+        "to_alias": "c",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "a.c_id",
+            "operator": "=",
+            "right_expr": "c.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [
+      {
+        "source": "a.id",
+        "target": "id",
+        "dtype": "integer"
+      }
+    ],
+    "target_frame": "tabOut01"
+  },
+  "invalid_left_expr_invalid_shape": {
+    "_doc": "left_expr has whitespace / no dot.",
+    "_expected_reason": "left_expr_invalid",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "a",
+        "source": "tabA01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "b",
+        "source": "tabB01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "a",
+        "to_alias": "b",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "a.id\n--",
+            "operator": "=",
+            "right_expr": "b.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "invalid_full_outer_on_databend": {
+    "_doc": "FULL join on Databend dialect rejected. Only fires when dialect='databend' passed.",
+    "_expected_reason": "full_outer_unsupported_on_dialect",
+    "_dialect": "databend",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "a",
+        "source": "tabA01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      },
+      {
+        "alias": "b",
+        "source": "tabB01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "a",
+        "to_alias": "b",
+        "join_type": "full",
+        "conditions": [
+          {
+            "left_expr": "a.id",
+            "operator": "=",
+            "right_expr": "b.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "invalid_cross_source_where": {
+    "_doc": "source_where for source 'sales' references another alias's column.",
+    "_expected_reason": "cross_source_where_ref",
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "sales",
+        "source": "tabSales01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          }
+        ],
+        "source_where": "cust.region == 'US'"
+      },
+      {
+        "alias": "cust",
+        "source": "tabCust01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "region",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "sales",
+        "to_alias": "cust",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "sales.id",
+            "operator": "=",
+            "right_expr": "cust.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [],
+    "target_frame": "tabOut01"
+  },
+  "valid_with_having_and_source_where": {
+    "operation": "frame_join_multi",
+    "sources": [
+      {
+        "alias": "sales",
+        "source": "tabSales01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "customer_id",
+            "dtype": "text"
+          },
+          {
+            "id": "total",
+            "dtype": "text"
+          }
+        ],
+        "source_where": "table1.customer_id > 0"
+      },
+      {
+        "alias": "cust",
+        "source": "tabCust01",
+        "source_columns": [
+          {
+            "id": "id",
+            "dtype": "text"
+          },
+          {
+            "id": "name",
+            "dtype": "text"
+          }
+        ]
+      }
+    ],
+    "edges": [
+      {
+        "from_alias": "sales",
+        "to_alias": "cust",
+        "join_type": "inner",
+        "conditions": [
+          {
+            "left_expr": "sales.customer_id",
+            "operator": "=",
+            "right_expr": "cust.id"
+          }
+        ]
+      }
+    ],
+    "target_columns": [
+      {
+        "source_alias": "sales",
+        "source": "sales.id",
+        "target": "sale_id",
+        "dtype": "integer"
+      },
+      {
+        "source_alias": "cust",
+        "source": "cust.name",
+        "target": "customer",
+        "dtype": "text"
+      }
+    ],
+    "target_frame": "tabOut01",
+    "having": "result.sale_id > 0"
+  }
+}

--- a/plaidcloud/utilities/tests/test_frame_join_multi_integration.py
+++ b/plaidcloud/utilities/tests/test_frame_join_multi_integration.py
@@ -1,0 +1,302 @@
+# coding=utf-8
+
+"""End-to-end integration tests for frame_join_multi.
+
+Round-10 caught that the validator and executor were diverging on the `source_columns[*]`
+key (validator validated `id`, executor's get_table_rep used `source` by default). No prior
+test exercised both layers against the same fixture. This file closes that gap: every test
+runs a config through validate_frame_join_multi_config AND through the SQL emission path,
+ensuring round-trip consistency.
+"""
+
+import copy
+import importlib.resources
+import json
+import unittest
+
+import sqlalchemy
+
+from plaidcloud.utilities.frame_join_multi_validator import (
+    validate_frame_join_multi_config,
+)
+from plaidcloud.utilities.sql_expression import (
+    edge_predicate,
+    get_table_rep,
+    topo_sort_edges,
+)
+
+
+def _load_fixtures():
+    files = importlib.resources.files('plaidcloud.utilities.test_fixtures')
+    with files.joinpath('frame_join_multi_config_fixtures.json').open() as f:
+        return json.load(f)
+
+
+FIXTURES = _load_fixtures()
+
+
+def _strip_meta(cfg):
+    return {k: v for k, v in cfg.items() if not k.startswith('_')}
+
+
+def _normalize_source_columns(cols):
+    """Mirrors the executor's normalization (synthesizes source=id and dtype=text default)
+    so the same key shape flows into get_table_rep / edge_predicate / source_from_clause
+    regardless of which key the original config used."""
+    return [
+        {**c, 'source': c.get('source', c['id']), 'dtype': c.get('dtype', 'text')}
+        for c in cols
+    ]
+
+
+class TestValidatorExecutorRoundTrip(unittest.TestCase):
+    """For each valid fixture, run validator + build sqlalchemy Tables + compile a predicate."""
+
+    def _build_tables(self, cfg):
+        """Mirror the executor's Step 1: per-source MetaData, normalized columns, aliased Table."""
+        tables_by_alias = {}
+        for s in cfg['sources']:
+            md = sqlalchemy.MetaData()
+            normalized = _normalize_source_columns(s['source_columns'])
+            base = get_table_rep(
+                s['source'],
+                normalized,
+                'anlz',
+                md,
+                alias=s['alias'],
+            )
+            tables_by_alias[s['alias']] = sqlalchemy.select(base).subquery(s['alias'])
+        return tables_by_alias
+
+    def test_valid_two_source_inner_builds_tables(self):
+        cfg = _strip_meta(FIXTURES['valid_two_source_inner'])
+        validate_frame_join_multi_config(cfg)
+        tables = self._build_tables(cfg)
+        # Tables are subqueries; their `.columns` must expose every column id from the config.
+        for s in cfg['sources']:
+            expected_cols = {c['id'] for c in s['source_columns']}
+            actual_cols = {c.name for c in tables[s['alias']].columns}
+            self.assertEqual(actual_cols, expected_cols,
+                             f"alias {s['alias']!r}: columns mismatch")
+
+    def test_valid_three_source_tree_predicate_compiles(self):
+        cfg = _strip_meta(FIXTURES['valid_three_source_tree'])
+        validate_frame_join_multi_config(cfg)
+        tables = self._build_tables(cfg)
+        # Topo-sort + build predicate for every edge.
+        ordered = topo_sort_edges(cfg['edges'], cfg['sources'][0]['alias'])
+        for edge in ordered:
+            pred = edge_predicate(edge, tables)
+            sql = str(pred.compile(compile_kwargs={'literal_binds': True}))
+            # Predicate must reference both endpoints' aliases in the rendered SQL.
+            self.assertIn(edge['from_alias'], sql)
+            self.assertIn(edge['to_alias'], sql)
+
+    def test_valid_all_operators_compiles(self):
+        cfg = _strip_meta(FIXTURES['valid_all_operators'])
+        validate_frame_join_multi_config(cfg)
+        tables = self._build_tables(cfg)
+        edge = cfg['edges'][0]
+        pred = edge_predicate(edge, tables)
+        # Don't inline binds — verify the compiled SQL has parameter placeholders for literals.
+        compiled = pred.compile()
+        sql = str(compiled)
+        # 13 operators in one edge — SQL should contain literal-binding placeholders, no
+        # raw injection-prone strings like '; DROP'.
+        self.assertNotIn('DROP', sql.upper())
+        # The pattern 'foo%' (LIKE) is in compiled.params, not in the SQL string.
+        self.assertIn('foo%', str(compiled.params.values()))
+
+    def test_valid_five_source_mixed_joins_compiles(self):
+        cfg = _strip_meta(FIXTURES['valid_five_source_mixed_joins'])
+        validate_frame_join_multi_config(cfg)
+        tables = self._build_tables(cfg)
+        ordered = topo_sort_edges(cfg['edges'], cfg['sources'][0]['alias'])
+        # Build the full join tree.
+        joined = tables[cfg['sources'][0]['alias']]
+        for edge in ordered:
+            child = tables[edge['to_alias']]
+            jt = edge['join_type']
+            if jt == 'cross':
+                pred = sqlalchemy.true()
+            else:
+                pred = edge_predicate(edge, tables)
+            if jt == 'inner' or jt == 'cross':
+                joined = sqlalchemy.join(joined, child, pred)
+            elif jt == 'left':
+                joined = sqlalchemy.outerjoin(joined, child, pred)
+            elif jt == 'full':
+                joined = sqlalchemy.join(joined, child, pred, full=True)
+        # Compile the joined FromClause into SQL — must not raise.
+        select_query = sqlalchemy.select(*tables[cfg['sources'][0]['alias']].columns).select_from(joined)
+        sql = str(select_query.compile(compile_kwargs={'literal_binds': True}))
+        # All five aliases must appear in the FROM tree.
+        for s in cfg['sources']:
+            self.assertIn(s['alias'], sql, f"alias {s['alias']!r} missing from compiled SQL")
+
+
+class TestHavingAndSourceWhereEndToEnd(unittest.TestCase):
+    """Round-13 closed the test-coverage gap: validator + executor + apply_output_filter +
+    get_combined_wheres flow against a fixture that uses both having and source_where."""
+
+    def _build_tables(self, cfg):
+        from plaidcloud.utilities.sql_expression import get_combined_wheres
+        tables_by_alias = {}
+        for s in cfg['sources']:
+            md = sqlalchemy.MetaData()
+            normalized = _normalize_source_columns(s['source_columns'])
+            base = get_table_rep(s['source'], normalized, 'anlz', md, alias=s['alias'])
+            sel = sqlalchemy.select(base)
+            where = s.get('source_where')
+            if where:
+                combined = get_combined_wheres([where], [base], {})
+                if combined:
+                    sel = sel.where(*combined)
+            tables_by_alias[s['alias']] = sel.subquery(s['alias'])
+        return tables_by_alias
+
+    def test_having_and_source_where_compile_end_to_end(self):
+        from plaidcloud.utilities.sql_expression import apply_output_filter, get_select_query
+        cfg = _strip_meta(FIXTURES['valid_with_having_and_source_where'])
+        validate_frame_join_multi_config(cfg)
+
+        tables_by_alias = self._build_tables(cfg)
+        # Build the JOIN (round-12: there's only one edge in this fixture).
+        joined = tables_by_alias[cfg['sources'][0]['alias']]
+        for edge in cfg['edges']:
+            child = tables_by_alias[edge['to_alias']]
+            from plaidcloud.utilities.sql_expression import edge_predicate
+            pred = edge_predicate(edge, tables_by_alias)
+            joined = sqlalchemy.join(joined, child, pred)
+
+        select_query = get_select_query(
+            tables=list(tables_by_alias.values()),
+            tables_by_alias=tables_by_alias,
+            source_columns=[_normalize_source_columns(s['source_columns']) for s in cfg['sources']],
+            target_columns=cfg['target_columns'],
+            wheres=None,
+            variables={},
+        ).select_from(joined)
+
+        # Apply the post-join filter.
+        select_query = apply_output_filter(select_query, cfg['having'], {})
+        # Compile without literal_binds — fixtures use text dtype so int comparisons would
+        # fail rendering. Bind parameters as placeholders instead.
+        sql = str(select_query.compile())
+
+        # The source_where (table1.customer_id > 0) should be inside the sales subquery.
+        self.assertIn('customer_id', sql, 'source_where column not in compiled SQL')
+        # The having (result.sale_id > 0) should reference the wrapped result subquery.
+        self.assertIn('sale_id', sql, 'having column not in compiled SQL')
+        # Outer wrap should be present.
+        self.assertIn('result', sql, 'apply_output_filter wrap missing from SQL')
+
+
+class TestCheckCartesianExplosionIntegration(unittest.TestCase):
+    """Round-13 closed the integration-test gap: cartesian guard against a config-shaped input."""
+
+    def test_cross_join_unknown_row_count_rejected(self):
+        """When a cross edge participates and one source's row count is unknown, the guard
+        cannot bound the product. The function itself doesn't enforce — but the executor
+        wraps with an unknown_counts check; here we verify the helper math at least doesn't
+        hide overflow when row_count_fn returns realistic values."""
+        from plaidcloud.utilities.sql_expression import check_cartesian_explosion
+
+        sources = [
+            {'alias': 'a', 'source': 'tabA'},
+            {'alias': 'b', 'source': 'tabB'},
+        ]
+        edges = [{'from_alias': 'a', 'to_alias': 'b', 'join_type': 'cross', 'conditions': []}]
+        # Both sources at 1M rows → 1T product. Should exceed any reasonable limit.
+        row_counts = {'tabA': 1_000_000, 'tabB': 1_000_000}
+        from plaidcloud.utilities.sql_expression import SQLExpressionError
+        with self.assertRaises(SQLExpressionError):
+            check_cartesian_explosion(
+                sources=sources, edges=edges,
+                row_count_fn=lambda t: row_counts[t],
+                row_limit=100_000_000,
+            )
+
+    def test_cross_join_within_limit_passes(self):
+        from plaidcloud.utilities.sql_expression import check_cartesian_explosion
+        sources = [
+            {'alias': 'a', 'source': 'tabA'},
+            {'alias': 'b', 'source': 'tabB'},
+        ]
+        edges = [{'from_alias': 'a', 'to_alias': 'b', 'join_type': 'cross', 'conditions': []}]
+        row_counts = {'tabA': 100, 'tabB': 200}  # 20k product
+        check_cartesian_explosion(
+            sources=sources, edges=edges,
+            row_count_fn=lambda t: row_counts[t],
+            row_limit=100_000_000,
+        )  # No raise.
+
+
+class TestGetSelectQueryEndToEnd(unittest.TestCase):
+    """Round-11 recommendation: exercise get_select_query (the path target_columns flow
+    through) against validated configs. This is the meta-fix preventing the next round-10/11
+    class of bug — every executor consumer must be tested against the validator's output."""
+
+    def test_get_select_query_compiles_for_two_source_inner(self):
+        from plaidcloud.utilities.sql_expression import get_select_query
+
+        cfg = _strip_meta(FIXTURES['valid_two_source_inner'])
+        validate_frame_join_multi_config(cfg)
+
+        tables_by_alias = {}
+        for s in cfg['sources']:
+            md = sqlalchemy.MetaData()
+            normalized = _normalize_source_columns(s['source_columns'])
+            base = get_table_rep(
+                s['source'], normalized, 'anlz', md, alias=s['alias'],
+            )
+            tables_by_alias[s['alias']] = sqlalchemy.select(base).subquery(s['alias'])
+
+        # This is the call that round-11 said wasn't being tested. If target_columns are
+        # missing required fields (target, dtype, agg, mode), get_from_clause raises here.
+        select_query = get_select_query(
+            tables=list(tables_by_alias.values()),
+            tables_by_alias=tables_by_alias,
+            source_columns=[_normalize_source_columns(s['source_columns']) for s in cfg['sources']],
+            target_columns=cfg['target_columns'],
+            wheres=None,
+            variables={},
+        )
+        sql = str(select_query.compile(compile_kwargs={'literal_binds': True}))
+        # Every target column's `target` name must appear in the SELECT list.
+        for tc in cfg['target_columns']:
+            self.assertIn(tc['target'], sql,
+                          f"target {tc['target']!r} missing from compiled SELECT")
+
+    def test_get_select_query_compiles_for_five_source(self):
+        from plaidcloud.utilities.sql_expression import get_select_query
+
+        cfg = _strip_meta(FIXTURES['valid_five_source_mixed_joins'])
+        validate_frame_join_multi_config(cfg)
+
+        tables_by_alias = {}
+        for s in cfg['sources']:
+            md = sqlalchemy.MetaData()
+            normalized = _normalize_source_columns(s['source_columns'])
+            base = get_table_rep(
+                s['source'], normalized, 'anlz', md, alias=s['alias'],
+            )
+            tables_by_alias[s['alias']] = sqlalchemy.select(base).subquery(s['alias'])
+
+        select_query = get_select_query(
+            tables=list(tables_by_alias.values()),
+            tables_by_alias=tables_by_alias,
+            source_columns=[_normalize_source_columns(s['source_columns']) for s in cfg['sources']],
+            target_columns=cfg['target_columns'],
+            wheres=None,
+            variables={},
+        )
+        # Just compile — if anything goes wrong with get_from_clause for any target column
+        # (missing dtype, bad agg, etc.), compile would raise.
+        sql = str(select_query.compile(compile_kwargs={'literal_binds': True}))
+        for tc in cfg['target_columns']:
+            self.assertIn(tc['target'], sql)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/plaidcloud/utilities/tests/test_frame_join_multi_sql_helpers.py
+++ b/plaidcloud/utilities/tests/test_frame_join_multi_sql_helpers.py
@@ -1,0 +1,427 @@
+# coding=utf-8
+
+"""Tests for the sql_expression helpers added for frame_join_multi:
+edge_predicate, topo_sort_edges, check_cartesian_explosion, get_column_table extension."""
+
+import unittest
+
+import sqlalchemy
+
+from plaidcloud.utilities.sql_expression import (
+    SQLExpressionError,
+    check_cartesian_explosion,
+    edge_predicate,
+    get_column_table,
+    topo_sort_edges,
+)
+
+
+def _make_table(name: str, columns: list[str]) -> sqlalchemy.Table:
+    """Build a sqlalchemy Table with the given columns (all Integer for simplicity)."""
+    md = sqlalchemy.MetaData()
+    return sqlalchemy.Table(
+        name, md,
+        *[sqlalchemy.Column(c, sqlalchemy.Integer) for c in columns],
+    )
+
+
+def _compile_sql(predicate) -> str:
+    """Compile a predicate to a SQL string with literal binds inlined — for assertion only."""
+    return str(predicate.compile(compile_kwargs={'literal_binds': True}))
+
+
+class TestEdgePredicateEqualityOperators(unittest.TestCase):
+
+    def setUp(self):
+        self.sales = _make_table('sales', ['id', 'customer_id', 'amt'])
+        self.cust = _make_table('cust', ['id', 'amt'])
+        self.tables = {'sales': self.sales, 'cust': self.cust}
+
+    def test_equality(self):
+        edge = {
+            'join_type': 'inner',
+            'conditions': [
+                {'left_expr': 'sales.customer_id', 'operator': '=', 'right_expr': 'cust.id'},
+            ],
+        }
+        sql = _compile_sql(edge_predicate(edge, self.tables))
+        self.assertIn('sales.customer_id', sql)
+        self.assertIn('cust.id', sql)
+        self.assertIn('=', sql)
+
+    def test_not_equal(self):
+        edge = {
+            'join_type': 'inner',
+            'conditions': [
+                {'left_expr': 'sales.amt', 'operator': '<>', 'right_expr': 'cust.amt'},
+            ],
+        }
+        sql = _compile_sql(edge_predicate(edge, self.tables))
+        self.assertIn('!=', sql)  # sqlalchemy renders <> as != on default dialect
+
+    def test_less_than(self):
+        edge = {
+            'join_type': 'inner',
+            'conditions': [
+                {'left_expr': 'sales.amt', 'operator': '<', 'right_expr': 'cust.amt'},
+            ],
+        }
+        sql = _compile_sql(edge_predicate(edge, self.tables))
+        self.assertIn('sales.amt < cust.amt', sql)
+
+    def test_multiple_conditions_anded(self):
+        edge = {
+            'join_type': 'inner',
+            'conditions': [
+                {'left_expr': 'sales.customer_id', 'operator': '=', 'right_expr': 'cust.id'},
+                {'left_expr': 'sales.amt', 'operator': '>=', 'right_expr': 'cust.amt'},
+            ],
+        }
+        sql = _compile_sql(edge_predicate(edge, self.tables))
+        self.assertIn('AND', sql.upper())
+
+
+class TestEdgePredicateNullOperators(unittest.TestCase):
+
+    def setUp(self):
+        self.sales = _make_table('sales', ['id', 'name'])
+        self.cust = _make_table('cust', ['id'])
+        self.tables = {'sales': self.sales, 'cust': self.cust}
+
+    def test_is_null(self):
+        edge = {
+            'join_type': 'left',
+            'conditions': [{'left_expr': 'sales.name', 'operator': 'IS NULL'}],
+        }
+        sql = _compile_sql(edge_predicate(edge, self.tables))
+        self.assertIn('IS NULL', sql.upper())
+        self.assertNotIn('IS NOT NULL', sql.upper())
+
+    def test_is_not_null(self):
+        edge = {
+            'join_type': 'left',
+            'conditions': [{'left_expr': 'sales.name', 'operator': 'IS NOT NULL'}],
+        }
+        sql = _compile_sql(edge_predicate(edge, self.tables))
+        self.assertIn('IS NOT NULL', sql.upper())
+
+
+class TestEdgePredicateLiteralBinding(unittest.TestCase):
+    """Critical: all literals must be bound parameters, never string-interpolated."""
+
+    def setUp(self):
+        self.sales = _make_table('sales', ['id', 'name', 'amt'])
+        self.cust = _make_table('cust', ['id'])
+        self.tables = {'sales': self.sales, 'cust': self.cust}
+
+    def test_like_pattern_is_bound_not_inlined(self):
+        edge = {
+            'join_type': 'inner',
+            'conditions': [
+                {'left_expr': 'sales.name', 'operator': 'LIKE', 'pattern': "foo'; DROP TABLE x; --"},
+            ],
+        }
+        # Compile WITHOUT literal_binds — pattern should appear as a bind parameter, not inlined
+        compiled = edge_predicate(edge, self.tables).compile()
+        sql = str(compiled)
+        # The dangerous string should NOT appear in the raw SQL — it's in the params dict
+        self.assertNotIn('DROP TABLE', sql)
+        self.assertIn("foo'; DROP TABLE x; --", str(compiled.params.values()))
+
+    def test_in_values_are_bound_not_inlined(self):
+        edge = {
+            'join_type': 'inner',
+            'conditions': [
+                {'left_expr': 'sales.id', 'operator': 'IN', 'in_values': [1, 2, "'; DROP --"]},
+            ],
+        }
+        compiled = edge_predicate(edge, self.tables).compile()
+        sql = str(compiled)
+        self.assertNotIn('DROP', sql)
+        self.assertIn("'; DROP --", str(compiled.params.values()))
+
+    def test_between_literal_bounds_are_bound(self):
+        edge = {
+            'join_type': 'inner',
+            'conditions': [
+                {'left_expr': 'sales.amt', 'operator': 'BETWEEN', 'between_low': 10, 'right_expr': 100},
+            ],
+        }
+        compiled = edge_predicate(edge, self.tables).compile()
+        sql = str(compiled)
+        # SQL has placeholders, not literal 10/100
+        self.assertNotIn(' 10 ', sql)
+        self.assertNotIn(' 100 ', sql)
+        param_vals = list(compiled.params.values())
+        self.assertIn(10, param_vals)
+        self.assertIn(100, param_vals)
+
+
+class TestEdgePredicateBetween(unittest.TestCase):
+
+    def setUp(self):
+        self.sales = _make_table('sales', ['id', 'amt'])
+        self.cust = _make_table('cust', ['low', 'high'])
+        self.tables = {'sales': self.sales, 'cust': self.cust}
+
+    def test_between_with_column_bounds(self):
+        edge = {
+            'join_type': 'inner',
+            'conditions': [
+                {'left_expr': 'sales.amt', 'operator': 'BETWEEN',
+                 'between_low': 'cust.low', 'right_expr': 'cust.high'},
+            ],
+        }
+        sql = _compile_sql(edge_predicate(edge, self.tables))
+        self.assertIn('BETWEEN', sql.upper())
+        self.assertIn('cust.low', sql)
+        self.assertIn('cust.high', sql)
+
+
+class TestEdgePredicateInOperators(unittest.TestCase):
+
+    def setUp(self):
+        self.a = _make_table('a', ['code'])
+        self.b = _make_table('b', ['id'])
+        self.tables = {'a': self.a, 'b': self.b}
+
+    def test_in_compiles_to_in_clause(self):
+        edge = {
+            'join_type': 'inner',
+            'conditions': [{'left_expr': 'a.code', 'operator': 'IN', 'in_values': ['x', 'y', 'z']}],
+        }
+        sql = _compile_sql(edge_predicate(edge, self.tables))
+        self.assertIn(' IN ', sql.upper())
+
+    def test_not_in_compiles_to_not_in(self):
+        edge = {
+            'join_type': 'inner',
+            'conditions': [{'left_expr': 'a.code', 'operator': 'NOT IN', 'in_values': ['x']}],
+        }
+        sql = _compile_sql(edge_predicate(edge, self.tables))
+        upper = sql.upper()
+        self.assertTrue('NOT IN' in upper or 'NOT (' in upper)
+
+
+class TestEdgePredicateUnknownReferences(unittest.TestCase):
+    """edge_predicate raises on missing alias/column. Defense-in-depth — validator should catch first."""
+
+    def setUp(self):
+        self.a = _make_table('a', ['id'])
+        self.tables = {'a': self.a}
+
+    def test_unknown_alias_raises(self):
+        edge = {
+            'join_type': 'inner',
+            'conditions': [{'left_expr': 'missing.id', 'operator': '=', 'right_expr': 'a.id'}],
+        }
+        with self.assertRaises(SQLExpressionError):
+            edge_predicate(edge, self.tables)
+
+    def test_unknown_column_raises(self):
+        edge = {
+            'join_type': 'inner',
+            'conditions': [{'left_expr': 'a.nonexistent', 'operator': 'IS NULL'}],
+        }
+        with self.assertRaises(SQLExpressionError):
+            edge_predicate(edge, self.tables)
+
+    def test_unsupported_operator_raises(self):
+        edge = {
+            'join_type': 'inner',
+            'conditions': [{'left_expr': 'a.id', 'operator': 'REGEXP', 'pattern': '.*'}],
+        }
+        with self.assertRaises(SQLExpressionError):
+            edge_predicate(edge, self.tables)
+
+
+class TestTopoSortEdges(unittest.TestCase):
+
+    def test_chain_in_order(self):
+        edges = [
+            {'from_alias': 'a', 'to_alias': 'b'},
+            {'from_alias': 'b', 'to_alias': 'c'},
+            {'from_alias': 'c', 'to_alias': 'd'},
+        ]
+        sorted_edges = topo_sort_edges(edges, root='a')
+        self.assertEqual([e['to_alias'] for e in sorted_edges], ['b', 'c', 'd'])
+
+    def test_chain_out_of_order_gets_sorted(self):
+        edges = [
+            {'from_alias': 'c', 'to_alias': 'd'},
+            {'from_alias': 'a', 'to_alias': 'b'},
+            {'from_alias': 'b', 'to_alias': 'c'},
+        ]
+        sorted_edges = topo_sort_edges(edges, root='a')
+        self.assertEqual([e['to_alias'] for e in sorted_edges], ['b', 'c', 'd'])
+
+    def test_fan_out_sibling_order_preserved(self):
+        """Root has two children. Order between siblings is the order they appear in edges."""
+        edges = [
+            {'from_alias': 'a', 'to_alias': 'b'},
+            {'from_alias': 'a', 'to_alias': 'c'},
+        ]
+        sorted_edges = topo_sort_edges(edges, root='a')
+        self.assertEqual([e['to_alias'] for e in sorted_edges], ['b', 'c'])
+
+    def test_fan_out_with_grandchildren(self):
+        edges = [
+            {'from_alias': 'a', 'to_alias': 'b'},
+            {'from_alias': 'a', 'to_alias': 'c'},
+            {'from_alias': 'b', 'to_alias': 'd'},
+        ]
+        sorted_edges = topo_sort_edges(edges, root='a')
+        # BFS order: b, c, d (b's child before c's children at same depth not relevant since c has none)
+        self.assertEqual([e['to_alias'] for e in sorted_edges], ['b', 'c', 'd'])
+
+    def test_diamond_raises(self):
+        edges = [
+            {'from_alias': 'a', 'to_alias': 'b'},
+            {'from_alias': 'a', 'to_alias': 'c'},
+            {'from_alias': 'b', 'to_alias': 'd'},
+            {'from_alias': 'c', 'to_alias': 'd'},
+        ]
+        with self.assertRaises(SQLExpressionError):
+            topo_sort_edges(edges, root='a')
+
+    def test_orphan_edges_raise(self):
+        edges = [
+            {'from_alias': 'a', 'to_alias': 'b'},
+            {'from_alias': 'x', 'to_alias': 'y'},
+        ]
+        with self.assertRaises(SQLExpressionError):
+            topo_sort_edges(edges, root='a')
+
+
+class TestCheckCartesianExplosion(unittest.TestCase):
+
+    def test_cross_within_limit_passes(self):
+        sources = [
+            {'alias': 'a', 'source': 'tabA'},
+            {'alias': 'b', 'source': 'tabB'},
+        ]
+        edges = [{'from_alias': 'a', 'to_alias': 'b', 'join_type': 'cross', 'conditions': []}]
+        row_counts = {'tabA': 100, 'tabB': 200}
+        check_cartesian_explosion(sources, edges, row_count_fn=lambda t: row_counts[t],
+                                  row_limit=100_000)
+        # No raise
+
+    def test_cross_over_limit_raises(self):
+        sources = [
+            {'alias': 'a', 'source': 'tabA'},
+            {'alias': 'b', 'source': 'tabB'},
+        ]
+        edges = [{'from_alias': 'a', 'to_alias': 'b', 'join_type': 'cross', 'conditions': []}]
+        row_counts = {'tabA': 1_000_000, 'tabB': 1_000_000}
+        with self.assertRaises(SQLExpressionError) as ctx:
+            check_cartesian_explosion(sources, edges, row_count_fn=lambda t: row_counts[t],
+                                      row_limit=1_000_000_000)
+        self.assertIn('cartesian explosion', str(ctx.exception))
+
+    def test_filtered_inner_join_does_not_explode(self):
+        """A regular inner join with conditions doesn't trigger the guard (predicates filter)."""
+        sources = [
+            {'alias': 'a', 'source': 'tabA'},
+            {'alias': 'b', 'source': 'tabB'},
+        ]
+        edges = [{'from_alias': 'a', 'to_alias': 'b', 'join_type': 'inner',
+                  'conditions': [{'left_expr': 'a.id', 'operator': '=', 'right_expr': 'b.id'}]}]
+        row_counts = {'tabA': 10_000_000_000, 'tabB': 10_000_000_000}
+        check_cartesian_explosion(sources, edges, row_count_fn=lambda t: row_counts[t],
+                                  row_limit=1_000_000)
+        # No raise — inner join with predicate is not counted
+
+    def test_hard_limit_clamps_user_limit(self):
+        sources = [
+            {'alias': 'a', 'source': 'tabA'},
+            {'alias': 'b', 'source': 'tabB'},
+        ]
+        edges = [{'from_alias': 'a', 'to_alias': 'b', 'join_type': 'cross', 'conditions': []}]
+        row_counts = {'tabA': 10**8, 'tabB': 10**8}
+        # User specifies a stupidly large limit; hard_limit should clamp
+        with self.assertRaises(SQLExpressionError):
+            check_cartesian_explosion(sources, edges, row_count_fn=lambda t: row_counts[t],
+                                      row_limit=10**20, hard_limit=10**15)
+
+
+class TestGetColumnTableExtension(unittest.TestCase):
+    """The keyword-only tables_by_alias parameter must:
+       1. Be honored when source_alias is set.
+       2. Not break any existing callers (positional path unchanged).
+       3. Reject ambiguous name-intersect when len(source_tables) > 2.
+    """
+
+    def setUp(self):
+        self.a = _make_table('a', ['id', 'name'])
+        self.b = _make_table('b', ['id', 'name'])
+        self.c = _make_table('c', ['id', 'name', 'unique_to_c'])
+        self.tables_list = [self.a, self.b, self.c]
+        self.columns = [
+            [{'source': 'id'}, {'source': 'name'}],
+            [{'source': 'id'}, {'source': 'name'}],
+            [{'source': 'id'}, {'source': 'name'}, {'source': 'unique_to_c'}],
+        ]
+        self.tables_by_alias = {'a': self.a, 'b': self.b, 'c': self.c}
+
+    def test_source_alias_resolved_via_tables_by_alias(self):
+        tc = {'source_alias': 'b', 'source': 'b.id'}
+        result = get_column_table(self.tables_list, tc, self.columns,
+                                  tables_by_alias=self.tables_by_alias)
+        self.assertIs(result, self.b)
+
+    def test_source_alias_without_tables_by_alias_raises(self):
+        tc = {'source_alias': 'b', 'source': 'b.id'}
+        with self.assertRaises(SQLExpressionError):
+            get_column_table(self.tables_list, tc, self.columns)
+
+    def test_source_alias_unknown_raises(self):
+        tc = {'source_alias': 'missing', 'source': 'missing.id'}
+        with self.assertRaises(SQLExpressionError):
+            get_column_table(self.tables_list, tc, self.columns,
+                             tables_by_alias=self.tables_by_alias)
+
+    def test_legacy_source_table_for_two_sources_unchanged(self):
+        tables_2 = [self.a, self.b]
+        cols_2 = [self.columns[0], self.columns[1]]
+        tc1 = {'source_table': 'table1', 'source': 'id'}
+        tc2 = {'source_table': 'table2', 'source': 'id'}
+        self.assertIs(get_column_table(tables_2, tc1, cols_2), self.a)
+        self.assertIs(get_column_table(tables_2, tc2, cols_2), self.b)
+
+    def test_legacy_source_table_for_three_sources_rejected(self):
+        tc = {'source_table': 'table1', 'source': 'id'}
+        with self.assertRaises(SQLExpressionError):
+            get_column_table(self.tables_list, tc, self.columns)
+
+    def test_tableN_positional_unchanged(self):
+        tc = {'source': 'table2.id'}
+        result = get_column_table(self.tables_list, tc, self.columns)
+        self.assertIs(result, self.b)
+
+    def test_name_intersect_unique_for_3_sources_resolves(self):
+        tc = {'source': 'unique_to_c'}
+        result = get_column_table(self.tables_list, tc, self.columns)
+        self.assertIs(result, self.c)
+
+    def test_name_intersect_ambiguous_for_3_sources_raises(self):
+        tc = {'source': 'name'}  # appears in all 3
+        with self.assertRaises(SQLExpressionError):
+            get_column_table(self.tables_list, tc, self.columns)
+
+    def test_name_intersect_for_2_sources_returns_first_match(self):
+        """Backwards-compat: existing binary-join behavior preserved."""
+        tables_2 = [self.a, self.b]
+        cols_2 = [self.columns[0], self.columns[1]]
+        tc = {'source': 'name'}  # in both
+        result = get_column_table(tables_2, tc, cols_2)
+        self.assertIs(result, self.a)
+
+    def test_one_source_shortcut(self):
+        """Single-table case shortcuts at line 132; no precedence rules apply."""
+        tc = {'source_alias': 'whatever', 'source': 'anything'}
+        result = get_column_table([self.a], tc, [self.columns[0]])
+        self.assertIs(result, self.a)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/plaidcloud/utilities/tests/test_frame_join_multi_validator.py
+++ b/plaidcloud/utilities/tests/test_frame_join_multi_validator.py
@@ -1,0 +1,483 @@
+# coding=utf-8
+
+"""Unit tests for the frame_join_multi config validator.
+
+Most of the heavy lifting is in the JSON fixture file shipped via package_data; each fixture
+declares whether it's valid or its expected `_expected_reason` token. This file:
+  (a) Loads fixtures and runs them through validate_frame_join_multi_config.
+  (b) Adds targeted tests for size caps, edge cases, and the dialect parameter.
+"""
+
+import copy
+import importlib.resources
+import json
+import unittest
+
+from plaidcloud.utilities.frame_join_multi_validator import (
+    JoinMultiValidationError,
+    JOIN_TYPES,
+    MAX_CONFIG_BYTES,
+    MAX_IN_VALUE_BYTES,
+    MAX_IN_VALUES,
+    MAX_PATTERN_LEN,
+    MAX_SOURCES,
+    OPERATORS,
+    RESERVED_ALIASES,
+    validate_frame_join_multi_config,
+)
+
+
+def _load_fixtures():
+    files = importlib.resources.files('plaidcloud.utilities.test_fixtures')
+    with files.joinpath('frame_join_multi_config_fixtures.json').open() as f:
+        return json.load(f)
+
+
+FIXTURES = _load_fixtures()
+
+
+def _strip_meta(cfg):
+    """Fixtures carry _doc / _expected_reason / _dialect metadata; the validator should ignore."""
+    out = {k: v for k, v in cfg.items() if not k.startswith('_')}
+    return out
+
+
+class TestFixtures(unittest.TestCase):
+    """Fixture-driven: each `valid_*` fixture must pass; each `invalid_*` must raise the
+    documented reason token."""
+
+    def test_valid_fixtures_pass(self):
+        for name, fixture in FIXTURES.items():
+            if name.startswith('_'):
+                continue
+            if not name.startswith('valid_'):
+                continue
+            with self.subTest(fixture=name):
+                cfg = _strip_meta(fixture)
+                validate_frame_join_multi_config(cfg)
+
+    def test_invalid_fixtures_raise_expected_reason(self):
+        for name, fixture in FIXTURES.items():
+            if not name.startswith('invalid_'):
+                continue
+            with self.subTest(fixture=name):
+                cfg = _strip_meta(fixture)
+                dialect = fixture.get('_dialect')
+                expected = fixture['_expected_reason']
+                # Some fixtures need a synth step to construct over-cap values that would
+                # bloat the JSON otherwise.
+                synth = fixture.get('_runtime_synth')
+                if synth == 'having_oversize':
+                    cfg['having'] = 'result.id > 0 and ' * 300  # ~6000 chars > 4096 cap
+                with self.assertRaises(JoinMultiValidationError) as ctx:
+                    validate_frame_join_multi_config(cfg, dialect=dialect)
+                self.assertEqual(ctx.exception.reason, expected,
+                                 f"fixture {name}: expected reason {expected!r}, got {ctx.exception.reason!r}")
+
+
+class TestShapeCaps(unittest.TestCase):
+    """Validator must short-circuit on shape caps before per-field validation, to bound CPU."""
+
+    def _minimal_valid(self):
+        return copy.deepcopy(FIXTURES['valid_two_source_inner'])
+
+    def test_config_not_dict_rejected(self):
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config("not a dict")
+        self.assertEqual(ctx.exception.reason, 'config_not_dict')
+
+    def test_config_too_large_rejected(self):
+        cfg = self._minimal_valid()
+        # Inflate source_columns on source[0] while keeping the required 'id' and 'customer_id'
+        # columns intact (so the edge condition still resolves). Pad with extra columns whose
+        # long ids push JSON over 256 KiB.
+        cfg['sources'][0]['source_columns'] = (
+            cfg['sources'][0]['source_columns']
+            + [{'id': f'pad_col_{i:06d}_' + 'x' * 100} for i in range(2500)]
+        )
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'config_too_large')
+
+    def test_sources_count_over_max(self):
+        cfg = _strip_meta(FIXTURES['valid_two_source_inner'])
+        cfg = copy.deepcopy(cfg)
+        # Inflate sources past MAX_SOURCES
+        cfg['sources'] = [
+            {'alias': f'a{i}', 'source': f'tabT{i:03d}', 'source_columns': [{'id': 'id'}]}
+            for i in range(MAX_SOURCES + 1)
+        ]
+        cfg['edges'] = []  # Will fail count check, but sources cap fires first
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'sources_count_out_of_range')
+
+
+class TestAliasRules(unittest.TestCase):
+
+    def _base(self):
+        return copy.deepcopy(_strip_meta(FIXTURES['valid_two_source_inner']))
+
+    def test_alias_too_long_rejected(self):
+        cfg = self._base()
+        cfg['sources'][0]['alias'] = 'a' * 64  # 64 chars; max is 63
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'alias_invalid')
+
+    def test_alias_starts_with_digit_rejected(self):
+        cfg = self._base()
+        cfg['sources'][0]['alias'] = '1sales'
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'alias_invalid')
+
+    def test_alias_with_newline_rejected(self):
+        """fullmatch + no MULTILINE flag rejects newlines."""
+        cfg = self._base()
+        cfg['sources'][0]['alias'] = 'sales\n'
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'alias_invalid')
+
+    def test_alias_case_insensitive_duplicate_rejected(self):
+        cfg = self._base()
+        cfg['sources'][0]['alias'] = 'Sales'
+        cfg['sources'][1]['alias'] = 'SALES'
+        cfg['edges'][0]['from_alias'] = 'Sales'
+        cfg['edges'][0]['to_alias'] = 'SALES'
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'alias_duplicate')
+
+    def test_every_reserved_alias_rejected(self):
+        for word in RESERVED_ALIASES:
+            cfg = self._base()
+            cfg['sources'][0]['alias'] = word
+            cfg['edges'][0]['from_alias'] = word
+            cfg['edges'][0]['conditions'][0]['left_expr'] = f'{word}.customer_id'
+            with self.subTest(word=word):
+                with self.assertRaises(JoinMultiValidationError) as ctx:
+                    validate_frame_join_multi_config(cfg)
+                self.assertEqual(ctx.exception.reason, 'alias_reserved')
+
+
+class TestSourceField(unittest.TestCase):
+    """source must be a strict TABLE_PREFIX UUID — closes the apply_variables + path-lookup
+    surface in workflow_runner's transform_handler.get_frame."""
+
+    def _base(self):
+        return copy.deepcopy(_strip_meta(FIXTURES['valid_two_source_inner']))
+
+    def test_path_style_source_rejected(self):
+        cfg = self._base()
+        cfg['sources'][0]['source'] = 'folder/path/to/table'
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'source_not_table_id')
+
+    def test_source_with_format_braces_rejected(self):
+        cfg = self._base()
+        cfg['sources'][0]['source'] = 'tab{tenant_secret}'
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'source_not_table_id')
+
+    def test_source_with_dot_dot_rejected(self):
+        cfg = self._base()
+        cfg['sources'][0]['source'] = 'tab..secrets'
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'source_not_table_id')
+
+    def test_source_without_tab_prefix_rejected(self):
+        cfg = self._base()
+        cfg['sources'][0]['source'] = 'someUUID123'
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'source_not_table_id')
+
+    def test_valid_table_prefix_accepted(self):
+        cfg = self._base()
+        cfg['sources'][0]['source'] = 'tabABC123_xyz-456'
+        validate_frame_join_multi_config(cfg)  # no raise
+
+
+class TestConditionShapes(unittest.TestCase):
+
+    def _three_source(self):
+        return copy.deepcopy(_strip_meta(FIXTURES['valid_three_source_tree']))
+
+    def test_unknown_operator_rejected(self):
+        cfg = self._three_source()
+        cfg['edges'][0]['conditions'][0]['operator'] = 'NEAR'
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'operator_invalid')
+
+    def test_unknown_left_expr_column_rejected(self):
+        cfg = self._three_source()
+        cfg['edges'][0]['conditions'][0]['left_expr'] = 'sales.nonexistent_col'
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'left_expr_column_unknown')
+
+    def test_pattern_too_long_rejected(self):
+        cfg = self._three_source()
+        cfg['edges'][0]['conditions'][0] = {
+            'left_expr': 'sales.customer_id',
+            'operator': 'LIKE',
+            'pattern': 'x' * (MAX_PATTERN_LEN + 1),
+        }
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'pattern_too_long')
+
+    def test_in_values_count_zero_rejected(self):
+        cfg = self._three_source()
+        cfg['edges'][0]['conditions'][0] = {
+            'left_expr': 'sales.customer_id',
+            'operator': 'IN',
+            'in_values': [],
+        }
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'in_values_count_out_of_range')
+
+    def test_in_values_element_too_large(self):
+        cfg = self._three_source()
+        cfg['edges'][0]['conditions'][0] = {
+            'left_expr': 'sales.customer_id',
+            'operator': 'IN',
+            'in_values': ['x' * (MAX_IN_VALUE_BYTES + 100)],
+        }
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'in_value_too_large')
+
+    def test_in_values_non_primitive(self):
+        cfg = self._three_source()
+        cfg['edges'][0]['conditions'][0] = {
+            'left_expr': 'sales.customer_id',
+            'operator': 'IN',
+            'in_values': [{'nested': 'dict'}],
+        }
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'in_value_not_primitive')
+
+    def test_between_with_column_bounds(self):
+        cfg = self._three_source()
+        cfg['edges'][0]['conditions'][0] = {
+            'left_expr': 'sales.customer_id',
+            'operator': 'BETWEEN',
+            'between_low': 'cust.id',
+            'right_expr': 'cust.id',
+        }
+        validate_frame_join_multi_config(cfg)  # no raise
+
+
+class TestDialectGating(unittest.TestCase):
+
+    def test_full_outer_passes_when_no_dialect_specified(self):
+        """Save-time hook has no dialect; FULL OUTER passes there. Executor catches it."""
+        cfg = _strip_meta(FIXTURES['invalid_full_outer_on_databend'])
+        validate_frame_join_multi_config(cfg, dialect=None)  # no raise
+
+    def test_full_outer_passes_on_starrocks(self):
+        cfg = _strip_meta(FIXTURES['invalid_full_outer_on_databend'])
+        validate_frame_join_multi_config(cfg, dialect='starrocks')  # no raise
+
+    def test_full_outer_rejected_on_databend(self):
+        cfg = _strip_meta(FIXTURES['invalid_full_outer_on_databend'])
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg, dialect='databend')
+        self.assertEqual(ctx.exception.reason, 'full_outer_unsupported_on_dialect')
+
+
+class TestErrorShape(unittest.TestCase):
+
+    def test_error_carries_field_locator(self):
+        cfg = copy.deepcopy(_strip_meta(FIXTURES['valid_two_source_inner']))
+        cfg['sources'][0]['alias'] = '1bad'
+        try:
+            validate_frame_join_multi_config(cfg)
+            self.fail('expected JoinMultiValidationError')
+        except JoinMultiValidationError as e:
+            self.assertEqual(e.code, 'JOIN_VALIDATION')
+            self.assertEqual(e.field, 'sources[0].alias')
+            self.assertEqual(e.reason, 'alias_invalid')
+
+
+class TestOperatorEnum(unittest.TestCase):
+    """The closed enum is the security contract — anything outside is rejected."""
+
+    def test_no_expr_operator(self):
+        self.assertNotIn('expr', OPERATORS)
+
+    def test_no_regexp(self):
+        self.assertNotIn('REGEXP', OPERATORS)
+
+    def test_no_null_safe_equality(self):
+        self.assertNotIn('<=>', OPERATORS)
+
+    def test_join_types_are_exactly_four(self):
+        self.assertEqual(JOIN_TYPES, frozenset({'inner', 'left', 'full', 'cross'}))
+
+
+class TestRound11ContractGaps(unittest.TestCase):
+    """Round-11 found that the validator didn't enforce fields the executor consumes.
+    Each test below exercises one of the new validator rules."""
+
+    def _base(self):
+        return copy.deepcopy(_strip_meta(FIXTURES['valid_two_source_inner']))
+
+    def test_target_frame_required(self):
+        cfg = self._base()
+        del cfg['target_frame']
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'target_frame_invalid')
+
+    def test_target_frame_must_match_table_prefix(self):
+        cfg = self._base()
+        cfg['target_frame'] = 'not_a_table_id'
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'target_frame_invalid')
+
+    def test_target_columns_target_required(self):
+        cfg = self._base()
+        del cfg['target_columns'][0]['target']
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'target_name_invalid')
+
+    def test_target_columns_target_duplicate_rejected(self):
+        cfg = self._base()
+        cfg['target_columns'][1]['target'] = cfg['target_columns'][0]['target']
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'target_name_duplicate')
+
+    def test_target_columns_dtype_required(self):
+        cfg = self._base()
+        del cfg['target_columns'][0]['dtype']
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'target_column_dtype_invalid')
+
+    def test_target_columns_dtype_must_be_in_enum(self):
+        cfg = self._base()
+        cfg['target_columns'][0]['dtype'] = 'bogus_type'
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'target_column_dtype_invalid')
+
+    def test_target_columns_agg_must_be_in_enum(self):
+        cfg = self._base()
+        cfg['target_columns'][0]['agg'] = 'not_a_real_agg'
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'target_column_agg_invalid')
+
+    def test_target_columns_expression_not_allowed(self):
+        cfg = self._base()
+        cfg['target_columns'][0]['expression'] = 'sales.id * 2'
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'target_column_expression_not_allowed')
+
+    def test_target_columns_mode_required(self):
+        cfg = self._base()
+        # Remove both `source` and `constant` — no mode key.
+        del cfg['target_columns'][0]['source']
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'target_column_mode_required')
+
+    def test_source_columns_dtype_required(self):
+        cfg = self._base()
+        del cfg['sources'][0]['source_columns'][0]['dtype']
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'source_column_dtype_invalid')
+
+    def test_source_columns_dtype_must_be_in_enum(self):
+        cfg = self._base()
+        cfg['sources'][0]['source_columns'][0]['dtype'] = 'bogus'
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'source_column_dtype_invalid')
+
+    def test_user_supplied_datastore_dialect_rejected_at_save_time(self):
+        """Save-time hook (dialect=None) must reject user-supplied datastore_dialect to
+        prevent FULL OUTER bypass on Databend tenants."""
+        cfg = self._base()
+        cfg['datastore_dialect'] = 'starrocks'
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg, dialect=None)
+        self.assertEqual(ctx.exception.reason, 'datastore_dialect_not_user_settable')
+
+    def test_user_supplied_datastore_dialect_accepted_at_execute_time(self):
+        """Execute-time validator (dialect=<framework-injected>) accepts the value since
+        the framework merged it in."""
+        cfg = self._base()
+        cfg['datastore_dialect'] = 'starrocks'  # framework injected
+        validate_frame_join_multi_config(cfg, dialect='starrocks')  # no raise
+
+
+class TestRound12HavingAndSourceWhereGaps(unittest.TestCase):
+    """Round-12 reconfirmed contract gaps for `having` and `source_where` paths that prior
+    rounds documented but never closed. Each test exercises one rule that round-12 added."""
+
+    def _base(self):
+        return copy.deepcopy(_strip_meta(FIXTURES['valid_two_source_inner']))
+
+    def test_whitespace_only_having_rejected(self):
+        cfg = self._base()
+        cfg['having'] = '   '
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'having_empty_or_whitespace')
+
+    def test_empty_string_having_accepted(self):
+        """Empty string having is equivalent to no having — accepted (validator treats as absent)."""
+        cfg = self._base()
+        cfg['having'] = ''
+        validate_frame_join_multi_config(cfg)
+
+    def test_valid_having_passes(self):
+        cfg = _strip_meta(FIXTURES['valid_with_having_and_source_where'])
+        validate_frame_join_multi_config(cfg)
+
+    def test_alias_qualified_source_where_rejected(self):
+        """source_where='alias.col > 0' fails at execute time because eval_expression's
+        safe_dict only has `table1`. Validator rejects to prevent the cryptic runtime error."""
+        cfg = self._base()
+        cfg['sources'][0]['source_where'] = 'sales.customer_id > 0'  # 'sales' is the alias
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'source_where_alias_qualified_ref')
+
+    def test_table1_qualified_source_where_accepted(self):
+        """table1.col is the canonical form per get_safe_dict's table_numbering_start=1."""
+        cfg = self._base()
+        cfg['sources'][0]['source_where'] = 'table1.customer_id > 0'
+        validate_frame_join_multi_config(cfg)
+
+    def test_bare_column_source_where_accepted(self):
+        """Bare column names should work; eval_expression's safe_dict exposes them."""
+        cfg = self._base()
+        cfg['sources'][0]['source_where'] = 'customer_id > 0'
+        validate_frame_join_multi_config(cfg)
+
+    def test_whitespace_only_source_where_treated_as_absent(self):
+        """Whitespace-only source_where is silently dropped (executor's `if where:` skips empty)."""
+        cfg = self._base()
+        cfg['sources'][0]['source_where'] = '   '
+        validate_frame_join_multi_config(cfg)  # no raise — treated as absent
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dynamic = ["version", "readme", "dependencies"]
 readme = {file = ["README.md"], content-type = "text/markdown"}
 dependencies = {file = ["requirements.txt"]}
 
+[tool.setuptools.package-data]
+"plaidcloud.utilities" = ["test_fixtures/*.json"]
+
 [tool.setuptools_scm]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Adds `frame_join_multi_validator.py` with the single-source-of-truth config validator (13 operators, 4 join types, tree topology, shape caps, stable reason tokens). Imported by both the plaid save-time hook and the workflow-runner executor.
- Adds `edge_predicate`, `topo_sort_edges`, `check_cartesian_explosion` helpers and extends `get_column_table` / `get_select_query` / `get_from_clause` / `source_from_clause` with a keyword-only `tables_by_alias` parameter (existing callers unaffected).
- 94 new tests in 3 suites (validator coverage, SQL-helper operator matrix + literal-binding verification, end-to-end validator↔executor integration). 0 regressions vs master.
- Ships `test_fixtures/frame_join_multi_config_fixtures.json` via `[tool.setuptools.package-data]` so plaid + workflow-runner can import the same fixtures via `importlib.resources.files`.

This is PR 1 of 4 for the multi-table join initiative. Foundational dependency — `plaid` and `workflow-runner` PRs bump the wheel pin to a release containing this code.

Design + 13 rounds of adversarial review history in the PlaidClient PR's `docs/PLAN_multi_table_join_step.md`.

## Test plan
- [ ] CI: pytest passes (94 new + existing regression suite)
- [ ] Release a new plaid-utilities wheel after merge so plaid + workflow-runner can bump their pins
- [ ] Validate the `package_data` declaration ships the fixtures (test wheel install + `importlib.resources.files('plaidcloud.utilities.test_fixtures')`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)