### PR TITLE
Silence expected SAWarning from safe_extract override

### DIFF
--- a/plaidcloud/utilities/sqlalchemy_functions.py
+++ b/plaidcloud/utilities/sqlalchemy_functions.py
@@ -1,7 +1,10 @@
 # coding=utf-8
 # pylint: disable=function-redefined
 
+import warnings
+
 import sqlalchemy
+from sqlalchemy.exc import SAWarning
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.sql.functions import FunctionElement, GenericFunction, ReturnTypeFromArgs, sum
 from sqlalchemy.types import Numeric, Boolean, Double
@@ -406,8 +409,17 @@ def compile_safe_to_timestamp_starrocks(element, compiler, **kw):
 #     return f"to_char({compiler.process(timestamp)}, {compiler.process(format)})"
 
 
-class safe_extract(GenericFunction):
-    name = 'extract'
+# Intentionally overrides SQLAlchemy's built-in `extract` so func.extract picks up
+# the timestamp-coercing variant below. Silence the expected override SAWarning.
+with warnings.catch_warnings():
+    warnings.filterwarnings(
+        "ignore",
+        message="The GenericFunction 'extract' is already registered.*",
+        category=SAWarning,
+    )
+
+    class safe_extract(GenericFunction):
+        name = 'extract'
 
 
 # This one should work with databend, assuming timestamp types are the same


### PR DESCRIPTION
safe_extract intentionally registers a GenericFunction named 'extract' so that func.extract(...) transparently picks up the timestamp-coercing variant. SQLAlchemy warns on every import because it sees this as overriding its built-in extract. Suppress that single, expected warning at the class-definition site rather than letting it pollute startup logs.