### PR TITLE
ci(claude-review): raise review --max-turns 12→30 and timeout 10→15

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -320,7 +320,7 @@ jobs:
     needs: triage
     if: needs.triage.outputs.verdict == 'haiku-review' || needs.triage.outputs.verdict == 'sonnet-review'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       # SECURITY: egress firewall — see rationale in the triage job. This is
       # the primary exfil control for the Bash + secrets review context.
@@ -363,7 +363,7 @@ jobs:
           # is still possible but noisy, visible, and token-scope-limited.
           claude_args: >-
             --model ${{ needs.triage.outputs.model }}
-            --max-turns 12
+            --max-turns 30
             --allowedTools Read,Grep,Glob,Bash
           prompt: |
             You are reviewing pull request #${{ github.event.pull_request.number }}


### PR DESCRIPTION
## What

In the `review` job of `.github/workflows/claude-review.yml`:

- `--max-turns` `12` → **`30`**
- `timeout-minutes` `10` → **`15`**

(triage=5, status=5, followup=10/`--max-turns 10` are unchanged.)

## Why (run data, plaid + cp-rest)

Recent real reviews showed `--max-turns 12` is below the working range, not just the tail:

| num_turns | wall-clock | outcome |
|---|---|---|
| 6 | ~2 min | success |
| 11 | 129s | success |
| 16 | 299s | success |
| 20 | 157s | success |
| 13 (capped @12) ×4 | 157–276s | **error_max_turns** |

- ~25–33% of *actually-run* reviews were failing purely by hitting the 12 cap (`error_max_turns`, `num_turns:13`), posting **no review** while still spending ~12 turns.
- Successful reviews legitimately used up to 20 turns; the review prompt has ~7–9 turns of fixed scaffold before any investigation, and multi-file PRs need 10–15 more.
- Turns, not time, was the binding constraint (a 16-turn review finished in 5 min, well under the old 10-min cap). `30` covers all observed successes plus headroom; at ~30 turns a slow run (~19 s/turn observed) can approach 10 min, so `timeout-minutes` is raised to `15` to keep time from becoming the new false-fail.

Identical change applied across all 11 repos that carry this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
