### PR TITLE
Decode Alteryx SpatialObj fields to WKT in yxdb_to_csv

### DIFF
--- a/plaidcloud/utilities/frame_manager.py
+++ b/plaidcloud/utilities/frame_manager.py
@@ -2464,6 +2464,37 @@ def parquet_to_csv(parquet_file_name: str, csv_file_name: str, start_row: int = 
 
 
 
+def _geojson_to_wkt(geojson: dict) -> str:
+    """Minimal GeoJSON -> WKT for Alteryx SpatialObj geometry.
+
+    Avoids a shapely dependency. Handles the geometry types the ``yxdb`` library's
+    ``spatial.to_geojson`` emits (Point, MultiPoint, LineString, MultiLineString,
+    Polygon, MultiPolygon).
+    """
+    geom_type = geojson.get('type')
+    coords = geojson.get('coordinates')
+
+    def ring(points):
+        return '(' + ', '.join(f'{x} {y}' for x, y in points) + ')'
+
+    if geom_type == 'Point':
+        return f'POINT ({coords[0]} {coords[1]})'
+    if geom_type == 'MultiPoint':
+        # OGC/ISO form parenthesizes each point -- strict WKT parsers require it.
+        return 'MULTIPOINT (' + ', '.join(f'({x} {y})' for x, y in coords) + ')'
+    if geom_type == 'LineString':
+        return 'LINESTRING ' + ring(coords)
+    if geom_type == 'MultiLineString':
+        return 'MULTILINESTRING (' + ', '.join(ring(line) for line in coords) + ')'
+    if geom_type == 'Polygon':
+        return 'POLYGON (' + ', '.join(ring(r) for r in coords) + ')'
+    if geom_type == 'MultiPolygon':
+        return 'MULTIPOLYGON (' + ', '.join(
+            '(' + ', '.join(ring(r) for r in poly) + ')' for poly in coords
+        ) + ')'
+    raise ValueError(f'Unsupported GeoJSON geometry type: {geom_type!r}')
+
+
 def yxdb_to_csv(
     yxdb_file_name: str,
     csv_file_name: str,
@@ -2494,6 +2525,10 @@ def yxdb_to_csv(
         raise ImportError(
             "yxdb package is required for yxdb_to_csv; install with `pip install yxdb`"
         )
+    try:
+        from yxdb import spatial as yxdb_spatial
+    except ImportError:
+        yxdb_spatial = None
 
     # `yxdb` exposes the reader in the yxdb.yxdb_reader submodule (the top-level
     # package is empty), and list_fields() returns YxdbField objects -- use
@@ -2501,9 +2536,36 @@ def yxdb_to_csv(
     reader = YxdbReader(path=yxdb_file_name)
     try:
         field_names = [field.name for field in reader.list_fields()]
+
+        # Alteryx SpatialObj fields read back as a binary blob (shapefile-shape
+        # layout). Decode ONLY those to WKT, so converted spatial workflows read
+        # .yxdb geometry the same way they read .TAB / executor geometry. Gate on
+        # the raw Alteryx type ("SpatialObj") rather than "value is bytes" so a
+        # generic Blob is never handed to the shape parser -- arbitrary bytes can
+        # make it raise (struct.error) or spin on a bogus point count. The raw
+        # type lives on the reader's internal metainfo fields; degrade to
+        # no-decode if that internal shape ever changes.
+        spatial_names = set()
+        if yxdb_spatial is not None:
+            try:
+                spatial_names = {
+                    f.name for f in reader._fields
+                    if getattr(f, 'data_type', '') == 'SpatialObj'
+                }
+            except Exception:
+                spatial_names = set()
+
+        def decode(name, value):
+            if name not in spatial_names or not isinstance(value, (bytes, bytearray)):
+                return value
+            try:
+                return _geojson_to_wkt(json.loads(yxdb_spatial.to_geojson(bytes(value))))
+            except Exception:
+                return value  # malformed spatial blob -- leave the raw value
+
         data = []
         while reader.next():
-            data.append([reader.read_name(name) for name in field_names])
+            data.append([decode(name, reader.read_name(name)) for name in field_names])
     finally:
         # YxdbReader has no context manager; close explicitly so a mid-read
         # error can't leak the file handle in a long-lived import worker.

--- a/plaidcloud/utilities/tests/test_frame_manager.py
+++ b/plaidcloud/utilities/tests/test_frame_manager.py
@@ -296,6 +296,33 @@ class TestFrameManager(unittest.TestCase):
         assert len(df) == 120
         assert df["Species"].iloc[0] == "Iris-setosa"
 
+    def test_geojson_to_wkt_point(self):
+        assert frame_manager._geojson_to_wkt(
+            {"type": "Point", "coordinates": [1.0, 2.0]}) == "POINT (1.0 2.0)"
+
+    def test_geojson_to_wkt_polygon(self):
+        assert frame_manager._geojson_to_wkt({
+            "type": "Polygon",
+            "coordinates": [[[-105.5, 44.2], [-105.4, 44.2], [-105.4, 44.3], [-105.5, 44.2]]],
+        }) == "POLYGON ((-105.5 44.2, -105.4 44.2, -105.4 44.3, -105.5 44.2))"
+
+    def test_yxdb_spatialobj_decodes_to_wkt(self):
+        """An Alteryx SpatialObj blob decodes to WKT (so .yxdb geometry reads like
+        .TAB/executor geometry), rather than landing in the CSV as raw bytes."""
+        import struct
+        import json as json_mod
+        spatial = pytest.importorskip("yxdb.spatial")
+        pts = [(-105.5, 44.2), (-105.4, 44.2), (-105.4, 44.3), (-105.5, 44.2)]
+        blob = (
+            struct.pack("<i", 5)                                  # shape type 5 = Polygon
+            + struct.pack("<4d", -105.5, 44.2, -105.4, 44.3)      # bbox
+            + struct.pack("<i", 1)                                # 1 part
+            + struct.pack("<q", len(pts))                         # point count
+            + b"".join(struct.pack("<2d", x, y) for x, y in pts)
+        )
+        wkt = frame_manager._geojson_to_wkt(json_mod.loads(spatial.to_geojson(blob)))
+        assert wkt == "POLYGON ((-105.5 44.2, -105.4 44.2, -105.4 44.3, -105.5 44.2))"
+
     def test_json_to_csv_handles_embedded_quotes(self):
         """csv.DictWriter path (json/avro): dropping escapechar (== quotechar)
         avoids the ValueError and doubles embedded quotes, so values round-trip."""


### PR DESCRIPTION
## What (Issue G)
A converted Alteryx workflow that imports a `.yxdb` with a spatial column (e.g. `05 Advanced/02 Map a trade area around a store`) failed downstream in spatial SQL: `Invalid WKT ... st_geometryfromwkt('b\x05\x00\x00\x00...')`. `yxdb_to_csv` read the `SpatialObj` field back as a raw binary blob (Alteryx's shapefile-shape layout) and wrote it into the CSV verbatim, so the imported column wasn't geometry the rest of the pipeline could parse.

## Fix
The `yxdb` library already decodes these blobs to GeoJSON (`yxdb.spatial.to_geojson`). Convert that GeoJSON to **WKT** so `.yxdb` geometry reads the same way as `.TAB`/executor geometry — which the spatial converter consumes via `st_geometryfromwkt` (CreatePoints/TradeArea/SpatialMatch/Distance). A small `_geojson_to_wkt` helper (Point/MultiPoint/Line/MultiLine/Polygon/MultiPolygon) avoids adding a shapely dependency.

Decode is **gated on the field's raw Alteryx type being `"SpatialObj"`** (read from the reader's metainfo, matching the `yxdb` lib's own `Blob`/`SpatialObj` distinction) — not on "the value is `bytes`". A generic `Blob` column is therefore never handed to the shape parser: arbitrary bytes whose leading bytes look like a shape type can make `to_geojson` raise (`struct.error`) or spin on a bogus point count. A malformed `SpatialObj` value also degrades to its raw value rather than aborting the whole import. Non-spatial files are byte-for-byte unchanged.

## Tests (pass locally on py3.11 with the real `yxdb` lib)
- `_geojson_to_wkt` for Point and Polygon
- a SpatialObj blob → WKT roundtrip via the real `yxdb.spatial.to_geojson`

## Release / rollout
plaid-utilities ships via a tagged GitHub Release → PyPI; after merge it needs a version bump + release, then a pin bump in plaid (`requirements.txt`) and workflow-runner (`requirements-base.txt`), then the bf2 image redeploy. Then re-run `02 Map a trade area` to confirm `.yxdb` geometry flows through the spatial chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)