### PR TITLE
fix(frame_join_multi): accept canonical analyzetable_ ids + alias expressions

### DIFF
--- a/plaidcloud/utilities/frame_join_multi_validator.py
+++ b/plaidcloud/utilities/frame_join_multi_validator.py
@@ -42,8 +42,17 @@ RESERVED_ALIASES = frozenset({
     'union', 'table', 'inner', 'left', 'right', 'full', 'cross', 'on',
 })
 
-_TABLE_PREFIX_RE = re.compile(r'tab[A-Za-z0-9_-]{1,64}')
+# A source/target table reference is the canonical `analyzetable_<uuid>` id that table_find/
+# table_upsert return and that frame_extract and frame_join_inner/outer also accept (get_frame()
+# resolves it). This is an identifier-shape safety gate only — it keeps dots, quotes, and
+# whitespace out of the SQL the executor emits; the real existence check is get_frame() at execute
+# time. Match the same id shape the rest of the platform uses (cf. core query.py _TABLE_ID_RE)
+# rather than the old `tab`-prefix that never matched a real `analyzetable_` id.
+_TABLE_ID_RE = re.compile(r'[A-Za-z0-9_][A-Za-z0-9_-]{0,127}')
 _ALIAS_RE = re.compile(r'[A-Za-z_][A-Za-z0-9_]{0,62}')
+# Positional table names the executor's expression namespace reserves (`table1`, `table2`, ...);
+# the bare `table` is in RESERVED_ALIASES. An alias matching these would be silently shadowed.
+_POSITIONAL_TABLE_RE = re.compile(r'table\d+')
 _COLUMN_REF_RE = re.compile(r'[A-Za-z_][A-Za-z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*')
 _COLUMN_ID_RE = re.compile(r'[A-Za-z_][A-Za-z0-9_]{0,62}')
 
@@ -152,14 +161,18 @@ def validate_frame_join_multi_config(config: dict, dialect: str | None = None) -
         alias = s.get('alias')
         if not isinstance(alias, str) or not _ALIAS_RE.fullmatch(alias):
             _err('alias_invalid', f'{sfield}.alias')
-        if alias.lower() in RESERVED_ALIASES:
+        # `table` and `table1`/`table2`/... are the positional names the executor exposes in the
+        # expression namespace (get_safe_dict). An alias colliding with one would be silently
+        # shadowed by the positional table — an expression `table1.col` would read the FIRST
+        # source, not this alias — so reject those names (the bare `table` is in RESERVED_ALIASES).
+        if alias.lower() in RESERVED_ALIASES or _POSITIONAL_TABLE_RE.fullmatch(alias.lower()):
             _err('alias_reserved', f'{sfield}.alias')
         if alias.lower() in aliases_lower_to_alias:
             _err('alias_duplicate', f'{sfield}.alias')
         aliases_lower_to_alias[alias.lower()] = alias
 
         source = s.get('source')
-        if not isinstance(source, str) or not _TABLE_PREFIX_RE.fullmatch(source):
+        if not isinstance(source, str) or not _TABLE_ID_RE.fullmatch(source):
             _err('source_not_table_id', f'{sfield}.source')
 
         source_columns = s.get('source_columns')
@@ -342,32 +355,50 @@ def validate_frame_join_multi_config(config: dict, dialect: str | None = None) -
         if agg is not None and (not isinstance(agg, str) or agg not in _AGG_ENUM):
             _err('target_column_agg_invalid', f'{tfield}.agg')
 
-        # Mode key: exactly one of (`source` for column-ref, `expression`, `constant`) must be
-        # set — unless dtype is a 'serial'/'bigserial' or magic-column type. `expression` is
-        # NOT allowed in frame_join_multi (it routes through eval_expression which is the
-        # pre-existing P0 risk in source_where/having; this step intentionally doesn't
-        # extend that surface to target columns).
-        if 'expression' in tc and tc.get('expression'):
-            _err('target_column_expression_not_allowed', f'{tfield}.expression')
+        # Mode key: exactly one of (`source` for a column-ref, `expression`, `constant`) must be
+        # set — unless dtype is a 'serial'/'bigserial' magic-column type. `expression` columns
+        # route through the executor's eval_expression (the same surface as source_where/having)
+        # and may reference the join aliases, which the executor exposes in the expression
+        # namespace. A multi-table CASE like `collectedbyname` can only be expressed this way.
+        # The executor selects "expression mode" with a truthy `if expression:` check
+        # (get_from_clause), so the validator mirrors that truthiness. An empty string is falsy
+        # in both (treated as no expression); a whitespace-only string is truthy but would crash
+        # compile() at execute time, so reject it here (same as `having`/`source_where`).
+        expression = tc.get('expression')
+        if expression is not None and not isinstance(expression, str):
+            _err('target_column_expression_not_string', f'{tfield}.expression')
+        has_expression = bool(expression)
+        if has_expression:
+            if not expression.strip():
+                _err('target_column_expression_empty', f'{tfield}.expression')
+            if len(expression) > 4096:
+                _err('target_column_expression_too_long', f'{tfield}.expression')
         mode_keys = [k for k in ('source', 'constant') if tc.get(k) not in (None, '')]
+        if has_expression:
+            mode_keys.append('expression')
         is_magic = dtype.lower() in {'serial', 'bigserial'} if isinstance(dtype, str) else False
         if not is_magic and len(mode_keys) != 1:
             _err('target_column_mode_required', tfield)
 
-        source_alias = tc.get('source_alias')
-        # source_alias must be a non-empty string. isinstance check first so we don't leak
-        # TypeError from the `in aliases_set` lookup when given a list/dict (round-6 R6-8).
-        if not isinstance(source_alias, str) or not source_alias:
-            _err('source_alias_required', f'{tfield}.source_alias')
-        if source_alias not in aliases_set:
-            _err('source_alias_unknown', f'{tfield}.source_alias')
-        # Cross-check: the target column's `source` must reference a column that exists in
-        # the chosen alias's source_columns. Round-6 caught the column-existence half; round-7
-        # closes the prefix-mismatch half (silent wrong-result if `source = 'a.col'` but
-        # `source_alias = 'b'` and `col` exists in both aliases — executor emits `b.col`).
+        # `source_alias` binds a source-column target to one source (the executor filters
+        # target_columns by source_alias when propagating column properties). Required for
+        # `source`-mode columns; `expression`/`constant`/magic columns aren't tied to a single
+        # source so they don't carry one. Round-5 required it uniformly to close a legacy
+        # `source_table` propagation hole — that hole only ever affected source-mode columns,
+        # so scoping the requirement to source-mode keeps it closed.
         src_field = tc.get('source')
         if isinstance(src_field, str) and src_field:
-            # `source` may be `alias.col` or just `col` per existing get_column_table conventions.
+            source_alias = tc.get('source_alias')
+            # isinstance check first so we don't leak TypeError from the `in aliases_set` lookup
+            # when given a list/dict (round-6 R6-8).
+            if not isinstance(source_alias, str) or not source_alias:
+                _err('source_alias_required', f'{tfield}.source_alias')
+            if source_alias not in aliases_set:
+                _err('source_alias_unknown', f'{tfield}.source_alias')
+            # Cross-check: the target column's `source` must reference a column that exists in
+            # the chosen alias's source_columns. Round-6 caught the column-existence half; round-7
+            # closes the prefix-mismatch half (silent wrong-result if `source = 'a.col'` but
+            # `source_alias = 'b'` and `col` exists in both aliases — executor emits `b.col`).
             if '.' in src_field:
                 prefix, col_part = src_field.split('.', 1)
                 if prefix != source_alias:
@@ -443,7 +474,7 @@ def validate_frame_join_multi_config(config: dict, dialect: str | None = None) -
     # target_frame: the destination table id. Required by the executor's get_frame() call.
     # Validator round-11 closed the gap (was unchecked).
     target_frame = config.get('target_frame')
-    if not isinstance(target_frame, str) or not _TABLE_PREFIX_RE.fullmatch(target_frame):
+    if not isinstance(target_frame, str) or not _TABLE_ID_RE.fullmatch(target_frame):
         _err('target_frame_invalid', 'target_frame')
 
     # datastore_dialect: derived server-side from tenant context, NOT user config. Save-time

--- a/plaidcloud/utilities/sql_expression.py
+++ b/plaidcloud/utilities/sql_expression.py
@@ -50,8 +50,8 @@ class SQLExpressionError(Exception):
 filter_nulls = curry(valfilter, lambda v: v is not None)
 
 
-def eval_expression(expression: str, variables: dict|None, tables: list[sqlalchemy.Table], extra_keys: dict = None, disable_variables: bool = False, table_numbering_start: int= 1):
-    safe_dict = get_safe_dict(tables, extra_keys, table_numbering_start=table_numbering_start)
+def eval_expression(expression: str, variables: dict|None, tables: list[sqlalchemy.Table], extra_keys: dict = None, disable_variables: bool = False, table_numbering_start: int= 1, tables_by_alias: dict|None = None):
+    safe_dict = get_safe_dict(tables, extra_keys, table_numbering_start=table_numbering_start, tables_by_alias=tables_by_alias)
 
     try:
         expression_with_variables = apply_variables(expression, variables)
@@ -257,7 +257,7 @@ def constant_from_clause(constant, sort_type: bool|None, cast_type: type[sqlalch
     return process_fn(sort_type, cast_type, None, name, trim_zeroes)(const)
 
 # TODO: write tests, though TestGetFromClause already covers this
-def expression_from_clause(expression: str, tables: list[sqlalchemy.Table], sort_type: bool|None, cast_type: type[sqlalchemy.types.TypeEngine]|None, agg_type: str|None, name: str, variables: dict = None, disable_variables: bool = False, table_numbering_start: int = 1, trim_zeroes: bool = False):
+def expression_from_clause(expression: str, tables: list[sqlalchemy.Table], sort_type: bool|None, cast_type: type[sqlalchemy.types.TypeEngine]|None, agg_type: str|None, name: str, variables: dict = None, disable_variables: bool = False, table_numbering_start: int = 1, trim_zeroes: bool = False, *, tables_by_alias: dict | None = None):
     """Get a representation of a target column based on an expression."""
     expr = eval_expression(
         expression.strip(),
@@ -265,6 +265,7 @@ def expression_from_clause(expression: str, tables: list[sqlalchemy.Table], sort
         tables,
         disable_variables=disable_variables,
         table_numbering_start=table_numbering_start,
+        tables_by_alias=tables_by_alias,
     )
     return process_fn(sort_type, cast_type, agg_type, name, trim_zeroes)(expr)
 
@@ -329,7 +330,7 @@ def get_from_clause(
     if constant:
         return constant_from_clause(constant, sort_type, cast_type, name, variables, disable_variables, trim_zeroes)
     if expression:
-        return expression_from_clause(expression, tables, sort_type, cast_type, agg_type, name, variables, disable_variables, table_numbering_start, trim_zeroes)
+        return expression_from_clause(expression, tables, sort_type, cast_type, agg_type, name, variables, disable_variables, table_numbering_start, trim_zeroes, tables_by_alias=tables_by_alias)
     if source:
         return source_from_clause(source, tables, target_column_config, source_column_configs, cast, sort_type, cast_type, agg_type, name, table_numbering_start, trim_zeroes, tables_by_alias=tables_by_alias)
     if target_column_config.get('dtype') in {'serial', 'bigserial'}:
@@ -387,7 +388,7 @@ class Result(object):
         }
 
 
-def get_safe_dict(tables: list[sqlalchemy.Table], extra_keys: dict|None = None, table_numbering_start: int = 1):
+def get_safe_dict(tables: list[sqlalchemy.Table], extra_keys: dict|None = None, table_numbering_start: int = 1, tables_by_alias: dict|None = None):
     """Returns a dict of 'builtins' and table accessor variables for user
     written expressions."""
     extra_keys = extra_keys or {}
@@ -474,7 +475,13 @@ def get_safe_dict(tables: list[sqlalchemy.Table], extra_keys: dict|None = None, 
     # Generate table1, table2, ...
     table_keys = {f'table{n}': table.columns for n, table in enumerate(tables, start=table_numbering_start)}
 
-    return merge(default_keys, table_keys, extra_keys)
+    # Expose each join source by its alias for steps (frame_join_multi) whose expressions
+    # reference aliases (`mdp.name`) rather than positions (`table1.name`). Merged first so the
+    # builtins, dtype names, and positional table keys always win a name clash — a pathological
+    # alias like `func` resolves to the builtin and never shadows it.
+    alias_keys = {alias: rep.columns for alias, rep in (tables_by_alias or {}).items()}
+
+    return merge(alias_keys, default_keys, table_keys, extra_keys)
 
 
 def get_table_rep(table_id: str, columns: list[dict], schema: str, metadata: sqlalchemy.MetaData|None = None, column_key: str = 'source', alias: str|None = None) -> sqlalchemy.Table|sqlalchemy.FromClause:

--- a/plaidcloud/utilities/tests/test_frame_join_multi_sql_helpers.py
+++ b/plaidcloud/utilities/tests/test_frame_join_multi_sql_helpers.py
@@ -11,7 +11,9 @@ from plaidcloud.utilities.sql_expression import (
     SQLExpressionError,
     check_cartesian_explosion,
     edge_predicate,
+    eval_expression,
     get_column_table,
+    get_safe_dict,
     topo_sort_edges,
 )
 
@@ -421,6 +423,47 @@ class TestGetColumnTableExtension(unittest.TestCase):
         tc = {'source_alias': 'whatever', 'source': 'anything'}
         result = get_column_table([self.a], tc, [self.columns[0]])
         self.assertIs(result, self.a)
+
+
+class TestExpressionAliasExposure(unittest.TestCase):
+    """frame_join_multi target-column expressions reference join aliases (`mdp.name`), not
+    positional `table1`/`table2`. get_safe_dict must expose each alias from tables_by_alias so
+    eval_expression can resolve them; without this the alias raises NameError at execute time."""
+
+    def setUp(self):
+        self.a = _make_table('analyzetable_aaa', ['id', 'firstname']).alias('up')
+        self.b = _make_table('analyzetable_bbb', ['id', 'name']).alias('mdp')
+        self.tables = [self.a, self.b]
+        self.tables_by_alias = {'up': self.a, 'mdp': self.b}
+
+    def test_get_safe_dict_exposes_aliases(self):
+        safe = get_safe_dict(self.tables, tables_by_alias=self.tables_by_alias)
+        # Aliases present in addition to the positional table1/table2 keys.
+        self.assertIn('up', safe)
+        self.assertIn('mdp', safe)
+        self.assertIn('table1', safe)
+        self.assertIs(safe['mdp'], self.b.columns)
+
+    def test_alias_qualified_expression_resolves(self):
+        # The smoking-gun expression shape from the ToS Collections join.
+        expr = "case((mdp.name.isnot(None), mdp.name), else_=up.firstname)"
+        rendered = eval_expression(expr, None, self.tables, tables_by_alias=self.tables_by_alias)
+        sql = _compile_sql(rendered)
+        self.assertIn('CASE', sql.upper())
+        self.assertIn('mdp.name', sql)
+        self.assertIn('up.firstname', sql)
+
+    def test_alias_unknown_without_tables_by_alias(self):
+        # Without alias exposure the alias name is undefined — the pre-fix failure mode.
+        expr = "mdp.name"
+        with self.assertRaises(SQLExpressionError):
+            eval_expression(expr, None, self.tables)
+
+    def test_builtins_win_alias_name_clash(self):
+        # A pathological alias named like a builtin must not shadow the builtin.
+        clash = {'func': self.b}
+        safe = get_safe_dict(self.tables, tables_by_alias=clash)
+        self.assertIs(safe['func'], sqlalchemy.func)
 
 
 if __name__ == '__main__':

--- a/plaidcloud/utilities/tests/test_frame_join_multi_validator.py
+++ b/plaidcloud/utilities/tests/test_frame_join_multi_validator.py
@@ -161,10 +161,26 @@ class TestAliasRules(unittest.TestCase):
                     validate_frame_join_multi_config(cfg)
                 self.assertEqual(ctx.exception.reason, 'alias_reserved')
 
+    def test_positional_table_alias_rejected(self):
+        # `table1`/`table2`/... are positional names the executor exposes in the expression
+        # namespace; an alias matching one would be silently shadowed (an expression `table1.col`
+        # would read the first source, not this alias). Reject them.
+        for word in ('table1', 'table2', 'TABLE1', 'table42'):
+            cfg = self._base()
+            cfg['sources'][0]['alias'] = word
+            cfg['edges'][0]['from_alias'] = word
+            cfg['edges'][0]['conditions'][0]['left_expr'] = f'{word}.customer_id'
+            with self.subTest(word=word):
+                with self.assertRaises(JoinMultiValidationError) as ctx:
+                    validate_frame_join_multi_config(cfg)
+                self.assertEqual(ctx.exception.reason, 'alias_reserved')
+
 
 class TestSourceField(unittest.TestCase):
-    """source must be a strict TABLE_PREFIX UUID — closes the apply_variables + path-lookup
-    surface in workflow_runner's transform_handler.get_frame."""
+    """source must be an identifier-shaped table id — accepts the canonical analyzetable_<uuid>
+    that table_find/table_upsert return (and every other step uses), while still closing the
+    apply_variables + path-lookup surface in workflow_runner's transform_handler.get_frame
+    (no dots, slashes, braces, or whitespace reach SQL emit)."""
 
     def _base(self):
         return copy.deepcopy(_strip_meta(FIXTURES['valid_two_source_inner']))
@@ -190,12 +206,13 @@ class TestSourceField(unittest.TestCase):
             validate_frame_join_multi_config(cfg)
         self.assertEqual(ctx.exception.reason, 'source_not_table_id')
 
-    def test_source_without_tab_prefix_rejected(self):
+    def test_canonical_analyzetable_source_accepted(self):
+        # Regression for the reported bug: the canonical analyzetable_<uuid> id that
+        # table_find/table_upsert return — and that frame_extract/frame_join_inner|outer
+        # already accept — must validate. The old `tab`-prefix regex rejected it.
         cfg = self._base()
-        cfg['sources'][0]['source'] = 'someUUID123'
-        with self.assertRaises(JoinMultiValidationError) as ctx:
-            validate_frame_join_multi_config(cfg)
-        self.assertEqual(ctx.exception.reason, 'source_not_table_id')
+        cfg['sources'][0]['source'] = 'analyzetable_53867b49-c8d9-4ceb-8272-79017344b3bb'
+        validate_frame_join_multi_config(cfg)  # no raise
 
     def test_valid_table_prefix_accepted(self):
         cfg = self._base()
@@ -339,12 +356,17 @@ class TestRound11ContractGaps(unittest.TestCase):
             validate_frame_join_multi_config(cfg)
         self.assertEqual(ctx.exception.reason, 'target_frame_invalid')
 
-    def test_target_frame_must_match_table_prefix(self):
+    def test_target_frame_rejects_non_identifier(self):
         cfg = self._base()
-        cfg['target_frame'] = 'not_a_table_id'
+        cfg['target_frame'] = 'folder/path/table'  # slash isn't an identifier char
         with self.assertRaises(JoinMultiValidationError) as ctx:
             validate_frame_join_multi_config(cfg)
         self.assertEqual(ctx.exception.reason, 'target_frame_invalid')
+
+    def test_target_frame_canonical_id_accepted(self):
+        cfg = self._base()
+        cfg['target_frame'] = 'analyzetable_27d0dd09-971f-4392-a84a-9426ba76342a'
+        validate_frame_join_multi_config(cfg)  # no raise
 
     def test_target_columns_target_required(self):
         cfg = self._base()
@@ -381,12 +403,40 @@ class TestRound11ContractGaps(unittest.TestCase):
             validate_frame_join_multi_config(cfg)
         self.assertEqual(ctx.exception.reason, 'target_column_agg_invalid')
 
-    def test_target_columns_expression_not_allowed(self):
+    def test_target_column_expression_accepted(self):
+        # Expression target columns are allowed: they render via the executor's eval_expression
+        # with the join aliases in scope, so a multi-alias CASE can be expressed. No source_alias
+        # is required (an expression isn't tied to a single source).
         cfg = self._base()
-        cfg['target_columns'][0]['expression'] = 'sales.id * 2'
+        cfg['target_columns'].append({
+            'target': 'computed', 'dtype': 'text',
+            'expression': "case((sales.id.isnot(None), sales.id), else_='x')",
+        })
+        validate_frame_join_multi_config(cfg)  # no raise
+
+    def test_target_column_expression_with_source_rejected(self):
+        # An expression AND a source on the same column is two modes — must be exactly one.
+        cfg = self._base()
+        cfg['target_columns'][0]['expression'] = 'sales.id * 2'  # tc[0] already has `source`
         with self.assertRaises(JoinMultiValidationError) as ctx:
             validate_frame_join_multi_config(cfg)
-        self.assertEqual(ctx.exception.reason, 'target_column_expression_not_allowed')
+        self.assertEqual(ctx.exception.reason, 'target_column_mode_required')
+
+    def test_target_column_whitespace_expression_rejected(self):
+        # A whitespace-only expression is truthy, so the executor's `if expression:` would select
+        # it and crash compile() with SyntaxError. Reject it at validation (matches having).
+        cfg = self._base()
+        cfg['target_columns'][0]['expression'] = '   '
+        with self.assertRaises(JoinMultiValidationError) as ctx:
+            validate_frame_join_multi_config(cfg)
+        self.assertEqual(ctx.exception.reason, 'target_column_expression_empty')
+
+    def test_target_column_empty_string_expression_ignored(self):
+        # Empty string is falsy in the executor too (`if expression:`), so it's treated as no
+        # expression — the column stays valid on its existing `source` mode.
+        cfg = self._base()
+        cfg['target_columns'][0]['expression'] = ''
+        validate_frame_join_multi_config(cfg)  # no raise
 
     def test_target_columns_mode_required(self):
         cfg = self._base()


### PR DESCRIPTION
## Problem
`frame_join_multi` failed at run time for **every** source-id format with `Invalid frame_join_multi configuration (reason=source_not_table_id, field=sources[0].source)`. The same canonical `analyzetable_<uuid>` ids run fine in `frame_extract`, `frame_join_inner`, and `frame_join_outer`.

**Root cause:** the table-id regex was `tab[A-Za-z0-9_-]{1,64}` — it only matches ids that *start with* `tab` (e.g. `table1`) and rejects the canonical `analyzetable_<uuid>` (starts with `a`). It gated both `sources[].source` and `target_frame`. This broke all single-step N-way joins, including Alteryx-converted workflows (whose `frame_join_multi` emit uses canonical ids — they were hitting the same bug).

## Changes
1. **Regex** `_TABLE_PREFIX_RE` → `_TABLE_ID_RE = [A-Za-z0-9_][A-Za-z0-9_-]{0,127}`. An identifier-shape safety gate that accepts `analyzetable_<uuid>` (and the legacy `tab` form) while still keeping dots / quotes / slashes / whitespace out of emitted SQL. `get_frame()` remains the real existence check. No ReDoS (linear, bounded).
2. **Allow `expression` target columns** (was rejected with `target_column_expression_not_allowed`). They render through the executor's `eval_expression` — the *same* surface binary joins, `source_where`, and `having` already use — so a multi-alias `CASE` (e.g. `collectedbyname`) can be expressed. Expression mode uses `bool(expression)` to exactly match the executor's `if expression:`; a whitespace-only expression is rejected (`target_column_expression_empty`, would crash `compile()`); `source_alias` is now required only for **source-mode** target columns (expression/constant/magic carry none — they're skipped by the executor's property-propagation loop).
3. **`sql_expression.py`: expose join aliases in expressions.** Thread `tables_by_alias` through `get_from_clause → expression_from_clause → eval_expression → get_safe_dict` so an expression can reference `mdp.name` (a join alias), not just positional `table1..tableN`. Aliases are merged **first** so builtins and positional keys always win a name clash. Purely additive — every existing caller defaults `tables_by_alias=None` and is byte-for-byte unaffected.

## Proof
- Reproduced the exact production error locally, then proved the fixed validator + `sql_expression` render the real 5-source ToS-Collections join to correct SQL — the alias-qualified `CASE` resolves: `CAST(CASE WHEN (mdp.name IS NOT NULL) THEN mdp.name WHEN (up.firstname IS NOT NULL) THEN concat(up.firstname, ' ', up.lastname) ELSE t.transactioncreatedby END ...) AS collectedbyname`.
- Full suite green: **461 passed, 5 skipped** (skips are unrelated optional deps).

## Tests
Canonical-id source/target_frame accepted; expression target column accepted (+ `source_alias` exemption, mode exclusivity, whitespace/empty handling); `get_safe_dict` alias exposure + builtin-clash safety + the pre-fix `NameError` failure mode.

## Release
Cut **v1.9.5** after merge (setuptools_scm tag → PyPI via `release.yml`); then bump the `plaidcloud-utilities` pin in `plaid` and `workflow-runner` from `1.9.2` to `1.9.5`.

## Review note
Independent automated Sonnet review was blocked by transient subagent-service overload (529s); a rigorous manual adversarial pass was done instead and caught one issue (the whitespace-expression validator/executor mismatch, now fixed). Will re-run the automated pass before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)