### PR TITLE
fix(security): block eval() sandbox escape in expression engine [sc-22664]

### DIFF
--- a/plaidcloud/utilities/sql_expression.py
+++ b/plaidcloud/utilities/sql_expression.py
@@ -3,6 +3,7 @@
 
 """Utility library for sqlalchemy metaprogramming used in analyze transforms"""
 
+import ast
 import re
 import uuid
 from copy import deepcopy
@@ -50,6 +51,41 @@ class SQLExpressionError(Exception):
 filter_nulls = curry(valfilter, lambda v: v is not None)
 
 
+# User-authored expressions are compiled and eval()'d. Even with a curated
+# namespace, CPython auto-injects the real builtins when globals lacks a
+# '__builtins__' key, and any reachable object can be walked back to them via
+# dunder attributes (``().__class__.__bases__[0].__subclasses__()``). That is a
+# remote-code-execution path. We close it two ways: get_safe_dict pins
+# '__builtins__' to {}, and this AST gate rejects dunder access and a denylist
+# of dangerous names before the expression is ever compiled.
+_FORBIDDEN_EVAL_NAMES = frozenset({
+    'eval', 'exec', 'compile', 'open', 'input', 'breakpoint', 'help',
+    'getattr', 'setattr', 'delattr', 'globals', 'locals', 'vars',
+    'memoryview', 'exit', 'quit', '__import__',
+})
+
+
+def assert_eval_safe(source: str) -> ast.Expression:
+    """Parse a user expression and reject Python-sandbox escape vectors.
+
+    Blocks dunder name/attribute access (the classic subclass-walk and
+    ``__import__``/``__builtins__`` routes) and a denylist of dangerous
+    builtins. Returns the parsed AST so the caller compiles the validated
+    tree rather than re-parsing the string. Raises ``SyntaxError`` on bad
+    syntax (callers already handle that) and ``SQLExpressionError`` on a
+    disallowed construct.
+    """
+    tree = ast.parse(source, mode='eval')
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr.startswith('__'):
+            raise SQLExpressionError(f'Disallowed attribute access: {node.attr!r}')
+        if isinstance(node, ast.Name) and (
+            node.id.startswith('__') or node.id in _FORBIDDEN_EVAL_NAMES
+        ):
+            raise SQLExpressionError(f'Disallowed name in expression: {node.id!r}')
+    return tree
+
+
 def eval_expression(expression: str, variables: dict|None, tables: list[sqlalchemy.Table], extra_keys: dict = None, disable_variables: bool = False, table_numbering_start: int= 1):
     safe_dict = get_safe_dict(tables, extra_keys, table_numbering_start=table_numbering_start)
 
@@ -61,7 +97,7 @@ def eval_expression(expression: str, variables: dict|None, tables: list[sqlalche
         else:
             raise
 
-    compiled_expression = compile(expression_with_variables, '<string>', 'eval')
+    compiled_expression = compile(assert_eval_safe(expression_with_variables), '<string>', 'eval')
 
     try:
         return eval(compiled_expression, safe_dict)
@@ -401,6 +437,11 @@ def get_safe_dict(tables: list[sqlalchemy.Table], extra_keys: dict|None = None, 
         raise SQLExpressionError(f'Could not run get_column: column {repr(col)} does not exist.')
 
     default_keys = {
+        # Pin builtins to empty so eval() can't fall back to the real
+        # builtins (CPython injects them when this key is absent). The
+        # expression language is SQLAlchemy — `func.*`, `cast`, type
+        # constants — and needs no Python builtins.
+        '__builtins__': {},
         'sqlalchemy': sqlalchemy,
         'and_': sqlalchemy.and_,
         'or_': sqlalchemy.or_,
@@ -1219,7 +1260,7 @@ def eval_rule(rule: str, variables: dict, tables: list, extra_keys=None, disable
         else:
             raise
 
-    compiled_expression = compile(expression_with_variables, '<string>', 'eval')
+    compiled_expression = compile(assert_eval_safe(expression_with_variables), '<string>', 'eval')
 
     try:
         return eval(compiled_expression, safe_dict)

--- a/plaidcloud/utilities/tests/test_sql_expression.py
+++ b/plaidcloud/utilities/tests/test_sql_expression.py
@@ -1877,5 +1877,37 @@ class TestGetUpdateQuery(TestSQLExpression):
         )
 
 
+class TestEvalSandbox(TestSQLExpression):
+    """User expressions are compiled and eval()'d; guard against escape."""
+    def setUp(self):
+        self.table = sqlalchemy.table('t', sqlalchemy.column('amount'), sqlalchemy.column('x'))
+
+    def test_blocks_import_rce(self):
+        with self.assertRaises(se.SQLExpressionError):
+            se.eval_expression("__import__('os').popen('id').read()", None, [self.table])
+
+    def test_blocks_dunder_subclass_walk(self):
+        with self.assertRaises(se.SQLExpressionError):
+            se.eval_expression("().__class__.__bases__[0].__subclasses__()", None, [self.table])
+
+    def test_blocks_forbidden_builtin(self):
+        for expr in ("getattr(table, 'amount')", "eval('1')", "open('/etc/passwd')"):
+            with self.assertRaises(se.SQLExpressionError):
+                se.eval_expression(expr, None, [self.table])
+
+    def test_no_builtins_in_namespace(self):
+        self.assertEqual(se.get_safe_dict([self.table])['__builtins__'], {})
+
+    def test_allows_legitimate_expressions(self):
+        for expr in (
+            "table.amount * 2",
+            "func.coalesce(table.x, 0)",
+            "cast(table.amount, Text)",
+            "get_column(table, 'amount')",
+            "and_(table.amount > 0, table.x < 10)",
+        ):
+            self.assertIsNotNone(se.eval_expression(expr, None, [self.table]))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Severity: CRITICAL — remote code execution

`eval_expression` / `eval_rule` compile and `eval()` user-authored expressions in a namespace with **no `__builtins__` key**. CPython then auto-injects the full real builtins, and there was no AST allowlist on this path — so a crafted expression runs arbitrary Python/shell in the app and workflow-runner processes.

### Confirmed (benign localhost PoC through the product validator)
Fed `__import__('os').popen('id').read()` as a transform-step column expression to the exact save-time validator (`get_simple_expression_sql` → `get_select_query` → `eval_expression`). `id` executed **and the validator returned success** — the malicious expression validates clean while running code. Runtime user is in the `docker` group → host-root reachable.

### Reachability (authenticated write)
Transform-step save validation (`transform.py:278`), `model_handler.py:988`, Table Explorer, and the workflow runner — via any `target_columns[].expression`, `source_where`, or `having`. `step_upsert` (MCP) is not on the catastrophic denylist, so a prompt-injected agent with step-write can plant it; it fires at validate time, no run required.

### Context
`data-explorer-service` previously sandboxed this `compile()/eval()`; retiring it moved the eval in-process. Per-tenant namespaces bound cross-tenant blast radius but not in-tenant escalation or prompt-injection.

## Fix
- `get_safe_dict` pins `__builtins__` to `{}`.
- New `assert_eval_safe` AST gate at **both** eval sites rejects dunder name/attribute access (blocks `__import__`, `__builtins__`, and `().__class__.__bases__[0].__subclasses__()`) plus a denylist of dangerous builtins (`eval/exec/open/getattr/globals/...`).
- The expression language is SQLAlchemy (`func.*`, `cast`, type constants), so removing Python builtins is non-breaking.

## Verification
- RCE payload + `getattr`/`eval`/`open` + subclass-walk → all raise `SQLExpressionError`.
- 5 legitimate expressions still compile (`table.amount * 2`, `func.coalesce`, `cast`, `get_column`, `and_`).
- New `TestEvalSandbox` (5 tests) passes.
- No regression: `test_sql_expression.py` is 87 failed / 46 passed both before and after (the 87 are pre-existing dialect skew in the local env, unrelated to this change).

## Follow-ups (separate tickets, lower severity — from the same audit)
MCP surface un-rate-limited; `query_run` unbounded `max_rows` (OOM); `connection_describe` leaks DB passwords to the model; chat `run_query` weaker SQL guard; no orchestrator recursion/cost budget; audit-log gaps on credential/ACL mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)