### PR TITLE
fix(query): flatten compiled SQL with a space, not by deleting newlines

### DIFF
--- a/plaidcloud/utilities/analyze_table.py
+++ b/plaidcloud/utilities/analyze_table.py
@@ -143,7 +143,10 @@ def compiled(sa_query, dialect='greenplum'):
     dialect = dialect or 'greenplum'  # Just in case someone sends a blank string, or a None by mistake
     eng = sqlalchemy.create_engine(f'{dialect}://127.0.0.1/', paramstyle='pyformat')
     compiled_query = sa_query.compile(dialect=eng.dialect, compile_kwargs={"render_postcompile": True})
-    return str(compiled_query).replace('\n', ''), compiled_query.params
+    # Flatten to one line with a SPACE, not '': dropping the newline outright
+    # welds tokens across clause boundaries on multi-line SQL (`"col"FROM`,
+    # `aliasJOIN`), producing invalid SQL.
+    return str(compiled_query).replace('\n', ' '), compiled_query.params
 
 
 def send_query(project, query, params=None, rpc=None):

--- a/plaidcloud/utilities/query.py
+++ b/plaidcloud/utilities/query.py
@@ -129,7 +129,10 @@ class Connection:
         compiled_query = sa_query.compile(dialect=self.dialect, compile_kwargs={"render_postcompile": True})
         logger.info(self.dialect.name)
         logger.info(str(compiled_query))
-        return str(compiled_query).replace('\n', ''), compiled_query.params
+        # Flatten to one line with a SPACE, not '': dropping the newline outright
+        # welds tokens across clause boundaries on multi-line SQL (`"col"FROM`,
+        # `aliasJOIN`), producing invalid SQL.
+        return str(compiled_query).replace('\n', ' '), compiled_query.params
 
     def get_csv(self, table: "str|Table", encoding="utf-8", clean=False):
         """Returns a file path to the entire table as a CSV file.

--- a/plaidcloud/utilities/tests/test_query.py
+++ b/plaidcloud/utilities/tests/test_query.py
@@ -323,6 +323,18 @@ class TestCompiled(unittest.TestCase):
         self.assertIn('a', q)
         self.assertIn(5, params.values())
 
+    def test_compile_flattens_embedded_newlines_with_space(self):
+        # Raw multi-line SQL (e.g. an AI/hand-authored extract) carries newlines
+        # with NO trailing space. Flattening must replace each newline with a
+        # space, not drop it, or tokens weld across clause boundaries
+        # (`"driver_name"FROM`) and the statement no longer parses.
+        conn = make_connection()
+        raw = sqlalchemy.text('SELECT a."driver_name"\nFROM t a\nWHERE a.x > 0')
+        q, _params = conn._compiled(raw)
+        self.assertNotIn('\n', q)
+        self.assertNotIn('"driver_name"FROM', q)
+        self.assertIn('"driver_name" FROM', q)
+
 
 # ---------------------------------------------------------------------------
 # Connection.get_csv / get_csv_by_query


### PR DESCRIPTION
## What

`str(compiled_query).replace('\n', '')` flattened compiled SQL to one line by **deleting** newlines. When a statement carries a newline with no trailing space — as raw multi-line SQL embedded via `sqlalchemy.text()` does (an AI- or hand-authored extract) — that welds tokens across clause boundaries:

```
"driver_name"FROM ...      rJOIN ...      "year"AND ...
```

…which the warehouse rejects with a syntax error. Normal sqlalchemy-rendered SQL happens to emit a trailing space before each newline, so it dodged the bug; embedded raw SQL does not.

Replacing the newline with a **space** keeps the single-line form valid in both cases.

## Where

- `Connection._compiled` (`query.py`) — the live RPC query path
- module-level `compiled()` (`analyze_table.py`) — same one-liner

## Test

Added `TestCompiled.test_compile_flattens_embedded_newlines_with_space`: compiles a `text()` whose newline has no trailing space and asserts the flattened output keeps `"driver_name" FROM` (not welded). Fails on the old `replace('\n', '')`.

## Context

Surfaced while building the AI "SQL Extract from prompt" feature in `plaid` (sc-21457), which generates pretty-printed multi-line SELECTs. The plaid side has a flatten-safe workaround (trailing space per line); this fixes the root cause so any hand-written multi-line extract SQL is safe too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
