### PR TITLE
feat(sql): add parse_date_time / str_to_date expression functions

### DIFF
--- a/plaidcloud/utilities/sqlalchemy_functions.py
+++ b/plaidcloud/utilities/sqlalchemy_functions.py
@@ -379,6 +379,19 @@ def compile_safe_to_timestamp_starrocks(element, compiler, **kw):
 
     return f"str_to_date({compiler.process(text)}, {compiler.process(datetime_format)})"
 
+
+# parse_date_time / str_to_date are aliases for to_timestamp — they parse a
+# formatted string into a datetime (e.g. func.parse_date_time(col, '%m/%d/%Y')).
+# Subclassing safe_to_timestamp reuses its per-dialect compilers (including the
+# postgres↔python format-string conversion).
+class parse_date_time(safe_to_timestamp):
+    name = 'parse_date_time'
+
+
+class str_to_date(safe_to_timestamp):
+    name = 'str_to_date'
+
+
 # Disabling safe_to_char - input can be date, integer, float, interval (not just date)
 # class safe_to_char(GenericFunction):
 #     name = 'to_char'

--- a/plaidcloud/utilities/tests/test_sqlalchemy_functions.py
+++ b/plaidcloud/utilities/tests/test_sqlalchemy_functions.py
@@ -624,3 +624,27 @@ class TestSafeDivideSR(StarrocksTest):
         self.assertEqual(100, compiled.params['safe_divide_3'])
         self.assertEqual(0, compiled.params['nullif_1'])
 
+
+class TestParseDateTime(BaseTest):
+    # parse_date_time / str_to_date are aliases for to_timestamp: each must compile
+    # to the same SQL as to_timestamp (only the function-name-derived bind prefix
+    # differs), on every dialect.
+    def _assert_aliases_to_timestamp(self):
+        reference = str(sqlalchemy.func.to_timestamp('05/14/2024', '%m/%d/%Y').compile(
+            dialect=self.eng.dialect, compile_kwargs={"render_postcompile": True}))
+        for alias in ('parse_date_time', 'str_to_date'):
+            compiled = str(getattr(sqlalchemy.func, alias)('05/14/2024', '%m/%d/%Y').compile(
+                dialect=self.eng.dialect, compile_kwargs={"render_postcompile": True}))
+            self.assertEqual(reference.replace('to_timestamp_', f'{alias}_'), compiled)
+
+    def test_aliases(self):
+        self._assert_aliases_to_timestamp()
+
+
+class TestParseDateTimeDB(TestParseDateTime, DatabendTest):
+    pass
+
+
+class TestParseDateTimeSR(TestParseDateTime, StarrocksTest):
+    pass
+


### PR DESCRIPTION
## Problem

Users can't parse a formatted date/time string in a PlaidCloud expression. The natural form

```
func.to_date(func.parse_date_time(get_column(table, 'ENTRY_DATE'), '%m/%d/%Y'))
```

fails because `parse_date_time` (and `str_to_date`) aren't registered — `func.X` proxies straight to the database, which has no `parse_date_time` function. (sc-21369)

## Fix

Register `parse_date_time` and `str_to_date` as `GenericFunction` aliases of the existing `to_timestamp` (`safe_to_timestamp`). Subclassing reuses its per-dialect compilers — `to_timestamp(...)` on Databend, `str_to_date(...)` on StarRocks — including the postgres↔python format-string conversion (`'%m/%d/%Y'` and `'MM/DD/YYYY'` both work). The aliases compile identically to `to_timestamp` on every dialect.

`to_timestamp` already produced exactly the requested behavior; this just exposes it under the two names users (and the AI assistant, per the story) reach for.

## Tests

Added `TestParseDateTime` (run on Databend and StarRocks) asserting both aliases compile to the same SQL as `to_timestamp`.

## Validation

- `py_compile` clean on both changed files.
- `pylint --errors-only`: the only findings are the pre-existing `E1102 func.cast is not callable` SQLAlchemy false positives that already exist 65× on `master` — none in the added lines.
- The DB/StarRocks dialect plugins aren't installed in my local env (a known dev-machine limitation), so the new dialect tests run in CI; the alias-equivalence logic was verified locally against SQLAlchemy's default dialect.

## Cross-repo follow-ups (separate PRs)

To surface these in the UI expression picker and the AI expression catalogue (which is **generated** from `PlaidClient/.../Constants.js`, not hand-maintained):
1. **PlaidClient** — add `parse_date_time` / `str_to_date` to the `EXPRESSIONS` block in `Constants.js`.
2. **plaid** — regenerate `plaid/app/ai/expression_catalogue.json` from the updated `Constants.js` (`scripts/generate_expression_catalogue.py`).

Closes sc-21369 — https://app.shortcut.com/plaidcloud/story/21369

🤖 Generated with [Claude Code](https://claude.com/claude-code)