### PR TITLE
perf(query): cache project schema + drop redundant Table.__new__ touch (sc-22839)

### DIFF
--- a/plaidcloud/utilities/query.py
+++ b/plaidcloud/utilities/query.py
@@ -96,6 +96,7 @@ class Connection:
         self.dialect = dialect_cls(paramstyle='pyformat')
         self._variables = self._NOT_LOADED
         self._udf = self._NOT_LOADED
+        self._project_schema = self._NOT_LOADED
 
     @property
     def variables(self):
@@ -730,6 +731,18 @@ class Connection:
             raise Exception('Project Id has not been set')
         return self._project_name
 
+    @property
+    def project_schema(self):
+        # The physical schema is stable for the life of the connection, so cache
+        # it rather than paying an RPC on every Table instantiation (there are
+        # ~10-15 per allocation step).
+        if self._project_schema is self._NOT_LOADED:
+            if self._project_id.startswith(SCHEMA_PREFIX):
+                self._project_schema = self._project_id
+            else:
+                self._project_schema = self.rpc.analyze.project.get_project_schema(project_id=self._project_id)
+        return self._project_schema
+
     def get_dimension(self, dimension_name):
         return self.dims.get_dimension(name=dimension_name, replace=False).hierarchy_table()
 
@@ -840,13 +853,20 @@ class Table(sqlalchemy.Table):
             # Only try to create a physical table if columns have been defined
             _rpc.analyze.table.touch(project_id=_project_id, table_id=_table_id, meta=columns, overwrite=overwrite)
 
+        # Whether the caller supplied columns decides which touch created the
+        # physical table (see the ensure-create below). Capture it before
+        # table_meta reassigns `columns` to the reflected metadata.
+        had_input_columns = bool(columns)
+
         columns = _rpc.analyze.table.table_meta(
             project_id=_project_id, table_id=_table_id,
         )
         if not columns:
             columns = []  # If the table doesn't actually exist, we assume it's got no columns
 
-        if _project_id.startswith(SCHEMA_PREFIX):
+        if isinstance(conn, Connection):
+            _schema = conn.project_schema
+        elif _project_id.startswith(SCHEMA_PREFIX):
             _schema = _project_id
         else:
             _schema = _rpc.analyze.project.get_project_schema(project_id=_project_id)
@@ -875,8 +895,11 @@ class Table(sqlalchemy.Table):
         table_object._table_id = _table_id
         table_object._schema = _schema
 
-        # table must be created in database, if it doesn't already exist
-        if columns:
+        # Ensure the physical table exists for the read path (e.g. get_table with
+        # no input columns). When the caller supplied columns the touch above
+        # already (re)created it with the intended schema, so a second touch here
+        # would only recreate the same table again (and re-run update_shape).
+        if columns and not had_input_columns:
             _rpc.analyze.table.touch(
                 project_id=_project_id, table_id=_table_id, meta=columns, overwrite=overwrite
             )

--- a/plaidcloud/utilities/tests/test_query.py
+++ b/plaidcloud/utilities/tests/test_query.py
@@ -898,16 +898,28 @@ class TestTable(unittest.TestCase):
 
     def test_write_path_touches_once(self):
         """When columns are supplied the physical table is (re)created by a single
-        touch; the constructor must not touch a second time (a redundant recreate
-        + update_shape)."""
+        touch carrying the caller's schema; the constructor must not touch a second
+        time (a redundant recreate + update_shape)."""
         Table(self.conn, 'some_table', columns=[{'id': 'c', 'dtype': 'numeric'}])
         self.assertEqual(self.rpc.analyze.table.touch.call_count, 1)
+        # The surviving touch is the input-meta one, so the table is created with
+        # the caller's intended schema (not the reflected table_meta).
+        self.assertEqual(
+            self.rpc.analyze.table.touch.call_args.kwargs['meta'],
+            [{'id': 'c', 'dtype': 'numeric'}],
+        )
 
     def test_read_path_still_ensures_table(self):
-        """get_table-style construction (no input columns) still touches once to
-        ensure the physical table exists."""
+        """get_table-style construction (no input columns) still touches once, with
+        the reflected schema, to ensure the physical table exists."""
         Table(self.conn, 'some_table')
         self.assertEqual(self.rpc.analyze.table.touch.call_count, 1)
+        # No input columns, so the surviving touch is the ensure-exists one built
+        # from the reflected table_meta.
+        self.assertEqual(
+            self.rpc.analyze.table.touch.call_args.kwargs['meta'],
+            [{'id': 'col1', 'dtype': 'numeric'}],
+        )
 
     def test_fully_qualified_name_uses_dialect(self):
         tbl = Table(self.conn, 'some_table')

--- a/plaidcloud/utilities/tests/test_query.py
+++ b/plaidcloud/utilities/tests/test_query.py
@@ -889,6 +889,26 @@ class TestTable(unittest.TestCase):
         self.assertEqual(tbl.schema, SCHEMA_PREFIX + 'something')
         rpc.analyze.project.get_project_schema.assert_not_called()
 
+    def test_project_schema_resolved_once_per_connection(self):
+        """The physical schema is stable per connection, so instantiating several
+        tables must not re-fetch it (one RPC, not one-per-table)."""
+        Table(self.conn, 'some_table')
+        Table(self.conn, 'some_table')
+        self.assertEqual(self.rpc.analyze.project.get_project_schema.call_count, 1)
+
+    def test_write_path_touches_once(self):
+        """When columns are supplied the physical table is (re)created by a single
+        touch; the constructor must not touch a second time (a redundant recreate
+        + update_shape)."""
+        Table(self.conn, 'some_table', columns=[{'id': 'c', 'dtype': 'numeric'}])
+        self.assertEqual(self.rpc.analyze.table.touch.call_count, 1)
+
+    def test_read_path_still_ensures_table(self):
+        """get_table-style construction (no input columns) still touches once to
+        ensure the physical table exists."""
+        Table(self.conn, 'some_table')
+        self.assertEqual(self.rpc.analyze.table.touch.call_count, 1)
+
     def test_fully_qualified_name_uses_dialect(self):
         tbl = Table(self.conn, 'some_table')
         result = tbl.fully_qualified_name(self.conn.dialect)


### PR DESCRIPTION
## Summary

Part of **sc-22839** task 3 (reduce `allocation_dim` step run time). This is the low-risk, **platform-wide** piece: it trims the per-`Table` metadata-RPC tax that dominates fixed step overhead. `Table.__new__` runs ~10-15 times per `allocation_dim` step (and constantly everywhere else), and was paying two avoidable RPCs each time.

### 1. Cache the project schema on the `Connection`
`Table.__new__` called `analyze.project.get_project_schema` on every instantiation. The physical schema is stable for the life of a connection, so it's now resolved once via a lazily-cached `Connection.project_schema` property (same `_NOT_LOADED` pattern as the existing `variables`/`udf` caches). Non-`Connection` callers fall back to the original inline RPC.

### 2. Drop the redundant write-path `touch`
The two `table.touch` calls in `Table.__new__` were **not** a trivial duplicate — line 843 reassigns `columns` from the input meta to the reflected `table_meta` between them, and `get_table` (no input columns) only ever reached the second. Server-side, `touch(overwrite=True)` does a **full recreate + `update_shape`**, so on every `save_data`-style call the second touch recreated the just-created table again and rebuilt reporting views a second time.

It's now gated on `not had_input_columns`:
- **write path** (columns supplied) → one touch, no redundant recreate;
- **read path** (`get_table`) → the ensure-exists touch is preserved unchanged.

## Tests
Added 3 cases to `TestTable` pinning the new contracts (write path touches once, read path still ensures once, schema resolved once per connection). Full suite green: **468 passed, 4 pre-existing skips**.

## Rollout note
Shared-lib change — it only reaches running workflow steps once a new plaid-utilities version is published and the pins in `workflow-runner/requirements-base.txt` and plaid's `requirements.txt` are bumped.

## Not included
The larger `allocation_dim`-specific win (collapsing the allocable→paths→mapping recreate/read-back chain with an inline `path_id`) is a deliberately separate, riskier follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)