### PR TITLE
Detect AMP-engine (.yxdb e2) files and fail with an actionable message

### DIFF
--- a/plaidcloud/utilities/frame_manager.py
+++ b/plaidcloud/utilities/frame_manager.py
@@ -2571,6 +2571,8 @@ def yxdb_to_csv(
 
     Raises:
         :class:`ImportError`: if the ``yxdb`` package is not installed.
+        :class:`ValueError`: if the file is in the unsupported AMP-engine
+            ("Alteryx e2 Database file") format.
     """
 
     try:
@@ -2580,6 +2582,20 @@ def yxdb_to_csv(
         raise ImportError(
             "yxdb package is required for yxdb_to_csv; install with `pip install yxdb`"
         )
+
+    # Alteryx's AMP engine writes a different .yxdb format (header "Alteryx e2
+    # Database file") whose spec is unpublished; the yxdb library only reads
+    # the classic format and dies on AMP files with a cryptic IOError, so
+    # detect it up front and explain how to get a readable file.
+    with open(yxdb_file_name, 'rb') as f:
+        if f.read(21).startswith(b'Alteryx e2 Database'):
+            raise ValueError(
+                f'{yxdb_file_name} was written by the Alteryx AMP engine, whose .yxdb format is '
+                'proprietary and unpublished, so it cannot be read here. In Alteryx, re-save the '
+                'file using the Output Data tool\'s "compatible with Designer 18.1 and older" '
+                'option (AMP can read and write both formats), or export the data to CSV, then '
+                're-import.'
+            )
 
     # The extractor factories are wired up while the reader parses the file
     # metadata, and the record builder looks the FixedDecimal factory up on

--- a/plaidcloud/utilities/tests/test_yxdb_to_csv.py
+++ b/plaidcloud/utilities/tests/test_yxdb_to_csv.py
@@ -153,6 +153,16 @@ def test_yxdb_to_csv_end_to_end(tmp_path):
     assert payload == '01abff'
 
 
+def test_amp_format_file_raises_actionable_error(tmp_path):
+    pytest.importorskip('yxdb')
+    yxdb_path = str(tmp_path / 'amp.yxdb')
+    with open(yxdb_path, 'wb') as f:
+        f.write(b'Alteryx e2 Database file' + b'\x00' * 488)
+
+    with pytest.raises(ValueError, match='AMP'):
+        yxdb_to_csv(yxdb_path, str(tmp_path / 'amp.csv'))
+
+
 def test_yxdb_fixed_decimal_override_is_restored(tmp_path):
     yxdb_extractors = pytest.importorskip('yxdb._extractors')
     original = yxdb_extractors.new_fixed_decimal_extractor


### PR DESCRIPTION
## Summary
- `yxdb_to_csv` now checks the file header before constructing `YxdbReader`: files written by Alteryx's AMP engine (header `Alteryx e2 Database file`, unpublished spec that no library can read) raise a clear `ValueError` instead of the yxdb library's cryptic `IOError`.
- The error tells the user exactly how to recover: re-save in Alteryx via the Output Data tool's "compatible with Designer 18.1 and older" option (AMP reads and writes both formats), or export to CSV and re-import.

## Tests
- New test: a synthetic file with the e2 header raises `ValueError` mentioning AMP.
- Full `test_yxdb_to_csv.py` suite: 15 passed (all existing classic-format tests unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)