### PR TITLE
Make generated SQLAlchemy functions pickleable

### DIFF
--- a/plaidcloud/utilities/sqlalchemy_functions.py
+++ b/plaidcloud/utilities/sqlalchemy_functions.py
@@ -1289,6 +1289,7 @@ _STARROCKS_FUNCTION_RENAMES = {
 def _register_starrocks_rename(databend_name, starrocks_name):
     func_cls = type(databend_name, (GenericFunction,),
                     {'name': databend_name, 'inherit_cache': True})
+    globals()[databend_name] = func_cls
 
     @compiles(func_cls, 'starrocks')
     def _compile(element, compiler, _name=starrocks_name, **kw):

--- a/plaidcloud/utilities/tests/test_sqlalchemy_functions.py
+++ b/plaidcloud/utilities/tests/test_sqlalchemy_functions.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+import pickle
 import unittest
 
 import datetime
@@ -645,6 +646,18 @@ class TestSafeDivideSR(StarrocksTest):
 # protocol) spells/arg-orders several differently. Each function preserves the
 # Databend/default spelling and specializes only StarRocks. StarRocks behavior
 # was verified live (paul-dev). Databend spelling is asserted unchanged.
+
+class TestGeneratedFunctionPickling(unittest.TestCase):
+    def test_generated_functions_are_pickleable(self):
+        for name in sf._STARROCKS_FUNCTION_RENAMES:
+            with self.subTest(name=name):
+                self.assertTrue(hasattr(sf, name))
+                self.assertEqual(sf.__name__, getattr(sf, name).__module__)
+                expr = getattr(sqlalchemy.func, name)('2020-01-01')
+                restored = pickle.loads(pickle.dumps(expr))
+                self.assertIs(type(expr), type(restored))
+                self.assertEqual(str(expr), str(restored))
+
 
 class TestConverterRenamesDatabend(DatabendTest):
     """Databend keeps the emitted name verbatim (no regression)."""


### PR DESCRIPTION
## Summary
- bind dynamically generated StarRocks SQLAlchemy function classes into the module namespace
- add regression coverage that every generated function class can round-trip through pickle

## Why
Workflow query serialization pickles SQLAlchemy expressions. The generated functions such as `to_year` and `to_month` registered with SQLAlchemy but were not available as `plaidcloud.utilities.sqlalchemy_functions.<name>`, so pickle could not resolve them after the Unio upgrade.

## Validation
- `/Users/inviscid/Projects/plaid-utilities/.venv/bin/pytest /private/tmp/plaid-utils-pickle-fix/plaidcloud/utilities/tests/test_sqlalchemy_functions.py -q` (99 passed)