### PR TITLE
sc-23402: drop write-scoped touch from the Table read path

### DIFF
--- a/plaidcloud/utilities/query.py
+++ b/plaidcloud/utilities/query.py
@@ -861,11 +861,6 @@ class Table(sqlalchemy.Table):
             # Only try to create a physical table if columns have been defined
             _rpc.analyze.table.touch(project_id=_project_id, table_id=_table_id, meta=columns, overwrite=overwrite)
 
-        # Whether the caller supplied columns decides which touch created the
-        # physical table (see the ensure-create below). Capture it before
-        # table_meta reassigns `columns` to the reflected metadata.
-        had_input_columns = bool(columns)
-
         columns = _rpc.analyze.table.table_meta(
             project_id=_project_id, table_id=_table_id,
         )
@@ -902,15 +897,6 @@ class Table(sqlalchemy.Table):
         table_object._project_id = _project_id
         table_object._table_id = _table_id
         table_object._schema = _schema
-
-        # Ensure the physical table exists for the read path (e.g. get_table with
-        # no input columns). When the caller supplied columns the touch above
-        # already (re)created it with the intended schema, so a second touch here
-        # would only recreate the same table again (and re-run update_shape).
-        if columns and not had_input_columns:
-            _rpc.analyze.table.touch(
-                project_id=_project_id, table_id=_table_id, meta=columns, overwrite=overwrite
-            )
 
         return table_object
 

--- a/plaidcloud/utilities/tests/test_query.py
+++ b/plaidcloud/utilities/tests/test_query.py
@@ -911,17 +911,12 @@ class TestTable(unittest.TestCase):
             [{'id': 'c', 'dtype': 'numeric'}],
         )
 
-    def test_read_path_still_ensures_table(self):
-        """get_table-style construction (no input columns) still touches once, with
-        the reflected schema, to ensure the physical table exists."""
+    def test_read_path_does_not_touch(self):
+        """get_table-style construction (no input columns) is a pure read and must
+        NOT call analyze.table.touch, which is write-scoped and does DDL. A
+        read-only viewer would otherwise be refused (sc-23402)."""
         Table(self.conn, 'some_table')
-        self.assertEqual(self.rpc.analyze.table.touch.call_count, 1)
-        # No input columns, so the surviving touch is the ensure-exists one built
-        # from the reflected table_meta.
-        self.assertEqual(
-            self.rpc.analyze.table.touch.call_args.kwargs['meta'],
-            [{'id': 'col1', 'dtype': 'numeric'}],
-        )
+        self.rpc.analyze.table.touch.assert_not_called()
 
     def test_fully_qualified_name_uses_dialect(self):
         tbl = Table(self.conn, 'some_table')


### PR DESCRIPTION
## Symptom
Saputo Panel **server** apps opened blank for a viewer with no Analyze role; adding `Analyze Read Only` still left UI controls empty; only `Analyze Read and Write` populated data. Consumers should not need workspace-wide write scope (that group carries `analyze.udf.write` — arbitrary server-side Python) merely to read a report.

## Root cause
`plaidcloud/utilities/query.py` — `Table.__new__` called `analyze.table.touch` on the **read** path (construction with no caller-supplied `columns=`, i.e. `get_table()` / `Table()`). `touch` is scoped `analyze.table.write` and performs DDL, so a read-only viewer was refused. Panel server apps issue every RPC as the *viewer's* token, so the viewer — not the app — hit the refusal. All three published Saputo server apps load data via `get_table()` with no `columns=` (26/26 calls), so every data path took this read path.

## Change
- `query.py` — remove the unconditional read-path ensure-touch block and the now-dead `had_input_columns` capture that only guarded it. The **write** path (`if columns:` touch) and `create_on_missing` (`analyze.table.create`) are untouched.
- Behaviour change: a pure read of a table whose physical table was never materialized now returns empty rather than silently creating it — intended.
- `tests/test_query.py` — inverted `test_read_path_still_ensures_table` → `test_read_path_does_not_touch` (asserts `touch` is not called with no input columns). `test_write_path_touches_once` unchanged.

## Verification
Runner (no venv in repo): `pip install -e ".[test]"`, python 3.11.

Fails-before (inverted test on unmodified source):
```
AssertionError: Expected 'touch' to not have been called. Called 1 times.
Calls: [call(project_id='proj-id-123', table_id='analyzetable_existing', meta=[{'id': 'col1', 'dtype': 'numeric'}], overwrite=False)].
1 failed in 12.03s
```
Passes-after:
```
pytest plaidcloud/utilities/tests/test_query.py -q
98 passed in 2.95s
```

## Caller sweep (plaid-utilities)
Read-path callers — `query.py:160`, `query.py:758` (`get_table`), `connect.py:98`, `frame_manager.py:407` — all read pre-existing tables and none rely on implicit physical-table creation. Write callers — `query.py:711`, `frame_manager.py:2719` — pass `columns=` and are unaffected. No internal caller needs a change.

## Out of scope (human release steps)
Base-image rebuild, `plaidcloud-utilities` pin bump in the panel base image, Saputo tenant pin bump, and the three app rebuilds are human release steps and are **not** in this PR. This PR is the `plaid-utilities` code change only.

Story: https://app.shortcut.com/plaidcloud/story/23402

🤖 Generated with [Claude Code](https://claude.com/claude-code)